### PR TITLE
model: Add `Metricset.Interval` string field

### DIFF
--- a/input/elasticapm/internal/modeldecoder/v2/metricset_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/metricset_test.go
@@ -76,6 +76,7 @@ func TestDecodeMapToMetricsetModel(t *testing.T) {
 		if key == "DocCount" ||
 			key == "Name" ||
 			key == "TimeseriesInstanceID" ||
+			key == "Interval" ||
 			// test Samples separately
 			strings.HasPrefix(key, "Samples") {
 			return true

--- a/model/metricset.go
+++ b/model/metricset.go
@@ -41,6 +41,11 @@ const (
 type Metricset struct {
 	// Name holds an optional name for the metricset.
 	Name string
+	// Interval holds the time period the metricset samples represent.
+	//
+	// The value is formatted in seconds, or minutes with the unit suffixed.
+	// Some examples include: `10s`, `1m`, `60m`.
+	Interval string
 	// Samples holds the metrics in the set.
 	Samples []MetricsetSample
 	// DocCount holds the document count for pre-aggregated metrics.
@@ -142,6 +147,7 @@ func (me *Metricset) setFields(fields *mapStr) {
 		fields.set("_doc_count", me.DocCount)
 	}
 	fields.maybeSetString("metricset.name", me.Name)
+	fields.maybeSetString("metricset.interval", me.Interval)
 
 	var metricDescriptions mapStr
 	for _, sample := range me.Samples {


### PR DESCRIPTION
## Description

Adds a new optional string field which is populated with the aggregation period for a given metricset.

## Related issues

Part of elastic/apm-server#9703
Required by elastic/apm-server#9846