### PR TITLE
BREAKING CHANGE: add serviceName to app logs dataset

### DIFF
--- a/model/modelprocessor/datastream.go
+++ b/model/modelprocessor/datastream.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	logsType       = "logs"
-	appLogsDataset = "apm.app"
-	errorsDataset  = "apm.error"
+	logsType              = "logs"
+	logDefaultServiceName = "unknown"
+	appLogsDataset        = "apm.app"
+	errorsDataset         = "apm.error"
 
 	metricsType            = "metrics"
 	appMetricsDataset      = "apm.app"
@@ -88,12 +89,16 @@ func isRUMAgentName(agentName string) bool {
 }
 
 func getAppLogsDataset(event *model.APMEvent) string {
-	if event.Service.Name == "" {
-		return appLogsDataset
+	serviceName := event.Service.Name
+	if serviceName == "" {
+		serviceName = logDefaultServiceName
 	}
+	var dataset strings.Builder
+	dataset.WriteString(appLogsDataset)
+	dataset.WriteByte('.')
+	dataset.WriteString(normalizeServiceName(serviceName))
 
-	suffix := normalizeServiceName(event.Service.Name)
-	return fmt.Sprintf("%s.%s", appLogsDataset, suffix)
+	return dataset.String()
 }
 
 func metricsetDataset(event *model.APMEvent) string {

--- a/model/modelprocessor/datastream.go
+++ b/model/modelprocessor/datastream.go
@@ -71,7 +71,7 @@ func (s *SetDataStream) setDataStream(event *model.APMEvent) {
 		event.DataStream.Dataset = errorsDataset
 	case model.LogProcessor:
 		event.DataStream.Type = logsType
-		event.DataStream.Dataset = appLogsDataset
+		event.DataStream.Dataset = getAppLogsDataset(event)
 	case model.MetricsetProcessor:
 		event.DataStream.Type = metricsType
 		event.DataStream.Dataset = metricsetDataset(event)
@@ -85,6 +85,15 @@ func isRUMAgentName(agentName string) bool {
 		return true
 	}
 	return false
+}
+
+func getAppLogsDataset(event *model.APMEvent) string {
+	if event.Service.Name == "" {
+		return appLogsDataset
+	}
+
+	suffix := normalizeServiceName(event.Service.Name)
+	return fmt.Sprintf("%s.%s", appLogsDataset, suffix)
 }
 
 func metricsetDataset(event *model.APMEvent) string {

--- a/model/modelprocessor/datastream_test.go
+++ b/model/modelprocessor/datastream_test.go
@@ -68,14 +68,21 @@ func TestSetDataStream(t *testing.T) {
 		input:  model.APMEvent{Processor: model.ErrorProcessor},
 		output: model.DataStream{Type: "logs", Dataset: "apm.error", Namespace: "custom"},
 	}, {
-		input:  model.APMEvent{Processor: model.LogProcessor},
-		output: model.DataStream{Type: "logs", Dataset: "apm.app", Namespace: "custom"},
+		input: model.APMEvent{
+			Processor: model.LogProcessor,
+			Service:   model.Service{Name: "service-name"},
+		},
+		output: model.DataStream{Type: "logs", Dataset: "apm.app.service_name", Namespace: "custom"},
 	}, {
 		input:  model.APMEvent{Processor: model.ErrorProcessor, Agent: model.Agent{Name: "iOS/swift"}},
 		output: model.DataStream{Type: "logs", Dataset: "apm.error", Namespace: "custom"},
 	}, {
-		input:  model.APMEvent{Processor: model.LogProcessor, Agent: model.Agent{Name: "iOS/swift"}},
-		output: model.DataStream{Type: "logs", Dataset: "apm.app", Namespace: "custom"},
+		input: model.APMEvent{
+			Processor: model.LogProcessor,
+			Agent:     model.Agent{Name: "iOS/swift"},
+			Service:   model.Service{Name: "service-name"},
+		},
+		output: model.DataStream{Type: "logs", Dataset: "apm.app.service_name", Namespace: "custom"},
 	}, {
 		input: model.APMEvent{
 			Agent:       model.Agent{Name: "rum-js"},

--- a/model/modelprocessor/datastream_test.go
+++ b/model/modelprocessor/datastream_test.go
@@ -70,6 +70,11 @@ func TestSetDataStream(t *testing.T) {
 	}, {
 		input: model.APMEvent{
 			Processor: model.LogProcessor,
+		},
+		output: model.DataStream{Type: "logs", Dataset: "apm.app.unknown", Namespace: "custom"},
+	}, {
+		input: model.APMEvent{
+			Processor: model.LogProcessor,
 			Service:   model.Service{Name: "service-name"},
 		},
 		output: model.DataStream{Type: "logs", Dataset: "apm.app.service_name", Namespace: "custom"},


### PR DESCRIPTION
BREAKING CHANGE
part of https://github.com/elastic/apm-server/issues/10291

Add service name to app logs dataset to create app logs datastream per service.