### PR TITLE
Bring default RepresentativeCount for Spans in line with Transactions

### DIFF
--- a/input/elasticapm/internal/modeldecoder/v2/decoder.go
+++ b/input/elasticapm/internal/modeldecoder/v2/decoder.go
@@ -1063,8 +1063,17 @@ func mapToSpanModel(from *span, event *model.APMEvent) {
 	if from.ParentID.IsSet() {
 		event.Parent.ID = from.ParentID.Val
 	}
-	if from.SampleRate.IsSet() && from.SampleRate.Val > 0 {
-		out.RepresentativeCount = 1 / from.SampleRate.Val
+	if from.SampleRate.IsSet() {
+		if from.SampleRate.Val > 0 {
+			out.RepresentativeCount = 1 / from.SampleRate.Val
+		}
+	} else {
+		// NOTE: we don't know the sample rate, so we need to make an assumption.
+		//
+		// Agents never send spans for non-sampled transactions, so assuming a
+		// representative count of 1 (i.e. sampling rate of 100%) may be invalid; but
+		// this is more useful than producing no metrics at all (i.e. assuming 0).
+		out.RepresentativeCount = 1
 	}
 	if len(from.Stacktrace) > 0 {
 		out.Stacktrace = make(model.Stacktrace, len(from.Stacktrace))

--- a/input/elasticapm/internal/modeldecoder/v2/span_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/span_test.go
@@ -195,11 +195,11 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		input.SampleRate.Set(0.25)
 		mapToSpanModel(&input, &out)
 		assert.Equal(t, 4.0, out.Span.RepresentativeCount)
-		// sample rate is not set
+		// sample rate is not set, default representative count should be 1
 		out.Span.RepresentativeCount = 0.0
 		input.SampleRate.Reset()
 		mapToSpanModel(&input, &out)
-		assert.Equal(t, 0.0, out.Span.RepresentativeCount)
+		assert.Equal(t, 1.0, out.Span.RepresentativeCount)
 		// sample rate is set to 0
 		input.SampleRate.Set(0)
 		mapToSpanModel(&input, &out)

--- a/input/elasticapm/internal/modeldecoder/v2/transaction_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/transaction_test.go
@@ -643,7 +643,8 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		var out model.APMEvent
 		mapToSpanModel(&input, &out)
 		assert.Equal(t, model.Span{
-			Type: "unknown",
+			Type:                "unknown",
+			RepresentativeCount: 1,
 		}, *out.Span)
 	})
 }


### PR DESCRIPTION
Relates: https://github.com/elastic/apm-server/pull/9458

I think we did not do this for spans because we assume new agents always
send `sample_rate` if `sample_rate > 0`

However this may not be true for non root transactions where the trace
was started by an external tool.

> For non-root transactions the agent MUST parse incoming tracestate headers to identify the es entry and extract the s attribute.
> The s attribute value should be used to populate the sample_rate field of transactions and spans.
> If there is no tracestate or no valid es entry with an s attribute, then the agent MUST omit sample_rate from non-root transactions and their spans.

See: https://github.com/elastic/apm/blob/main/specs/agents/tracing-sampling.md#propagation

This in turn means we won't collect span metrics for these transactions
