### PR TITLE
model: test JSON encoding, not "fields" methods

### DIFF
--- a/model/agent_test.go
+++ b/model/agent_test.go
@@ -30,18 +30,18 @@ const (
 func TestAgentFields(t *testing.T) {
 	tests := []struct {
 		Agent  Agent
-		Fields map[string]any
+		Output any
 	}{
 		{
 			Agent:  Agent{},
-			Fields: nil,
+			Output: nil,
 		},
 		{
 			Agent: Agent{
 				Name:    agentName,
 				Version: agentVersion,
 			},
-			Fields: map[string]any{
+			Output: map[string]any{
 				"name":    "elastic-node",
 				"version": "1.0.0",
 			},
@@ -49,6 +49,7 @@ func TestAgentFields(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.Fields, test.Agent.fields())
+		out := transformAPMEvent(APMEvent{Agent: test.Agent})
+		assert.Equal(t, test.Output, out["agent"])
 	}
 }

--- a/model/client_test.go
+++ b/model/client_test.go
@@ -29,21 +29,21 @@ func TestClientFields(t *testing.T) {
 		domain string
 		ip     netip.Addr
 		port   int
-		out    map[string]any
+		out    any
 	}{
 		"Empty":  {out: nil},
 		"IPv4":   {ip: netip.MustParseAddr("192.0.0.1"), out: map[string]any{"ip": "192.0.0.1"}},
 		"IPv6":   {ip: netip.MustParseAddr("2001:db8::68"), out: map[string]any{"ip": "2001:db8::68"}},
-		"Port":   {port: 123, out: map[string]any{"port": 123}},
+		"Port":   {port: 123, out: map[string]any{"port": 123.0}},
 		"Domain": {domain: "testing.invalid", out: map[string]any{"domain": "testing.invalid"}},
 	} {
 		t.Run(name, func(t *testing.T) {
-			c := Client{
+			out := transformAPMEvent(APMEvent{Client: Client{
 				Domain: tc.domain,
 				IP:     tc.ip,
 				Port:   tc.port,
-			}
-			assert.Equal(t, tc.out, c.fields())
+			}})
+			assert.Equal(t, tc.out, out["client"])
 		})
 	}
 }

--- a/model/cloud_test.go
+++ b/model/cloud_test.go
@@ -26,7 +26,7 @@ import (
 func TestCloudFields(t *testing.T) {
 	tests := []struct {
 		Cloud  Cloud
-		Output map[string]any
+		Output any
 	}{
 		{
 			Cloud:  Cloud{},
@@ -69,7 +69,7 @@ func TestCloudFields(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Cloud.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{Cloud: test.Cloud})
+		assert.Equal(t, test.Output, output["cloud"])
 	}
 }

--- a/model/container_test.go
+++ b/model/container_test.go
@@ -28,7 +28,7 @@ func TestContainerTransform(t *testing.T) {
 
 	tests := []struct {
 		Container Container
-		Output    map[string]any
+		Output    any
 	}{
 		{
 			Container: Container{},
@@ -57,7 +57,7 @@ func TestContainerTransform(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Container.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{Container: test.Container})
+		assert.Equal(t, test.Output, output["container"])
 	}
 }

--- a/model/device_test.go
+++ b/model/device_test.go
@@ -26,7 +26,7 @@ import (
 func TestDeviceFields(t *testing.T) {
 	tests := []struct {
 		Device Device
-		Output map[string]any
+		Output any
 	}{
 		{
 			Device: Device{},
@@ -53,7 +53,7 @@ func TestDeviceFields(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Device.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{Device: test.Device})
+		assert.Equal(t, test.Output, output["device"])
 	}
 }

--- a/model/kubernetes_test.go
+++ b/model/kubernetes_test.go
@@ -28,7 +28,7 @@ func TestKubernetesTransform(t *testing.T) {
 
 	tests := []struct {
 		Kubernetes Kubernetes
-		Output     map[string]any
+		Output     any
 	}{
 		{
 			Kubernetes: Kubernetes{},
@@ -53,7 +53,7 @@ func TestKubernetesTransform(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Kubernetes.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{Kubernetes: test.Kubernetes})
+		assert.Equal(t, test.Output, output["kubernetes"])
 	}
 }

--- a/model/log_test.go
+++ b/model/log_test.go
@@ -26,7 +26,7 @@ import (
 func TestLogTransform(t *testing.T) {
 	tests := []struct {
 		Log    Log
-		Output map[string]any
+		Output any
 	}{
 		{
 			Log:    Log{},
@@ -61,7 +61,7 @@ func TestLogTransform(t *testing.T) {
 					"function": "testFunc",
 					"file": map[string]any{
 						"name": "testFile",
-						"line": 12,
+						"line": 12.0,
 					},
 				},
 			},
@@ -69,7 +69,7 @@ func TestLogTransform(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Log.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{Log: test.Log})
+		assert.Equal(t, test.Output, output["log"])
 	}
 }

--- a/model/network_test.go
+++ b/model/network_test.go
@@ -26,7 +26,7 @@ import (
 func TestNetworkTransform(t *testing.T) {
 	tests := []struct {
 		Network Network
-		Output  map[string]any
+		Output  any
 	}{
 		{
 			Network: Network{},
@@ -61,7 +61,7 @@ func TestNetworkTransform(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Network.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{Network: test.Network})
+		assert.Equal(t, test.Output, output["network"])
 	}
 }

--- a/model/process_test.go
+++ b/model/process_test.go
@@ -27,15 +27,11 @@ func TestProcessTransform(t *testing.T) {
 	processTitle := "node"
 	commandLine := "node run.js"
 	executablePath := "/usr/bin/node"
-	argv := []string{
-		"node",
-		"server.js",
-	}
 
 	ppid := 456
 	tests := []struct {
 		Process Process
-		Output  map[string]any
+		Output  any
 	}{
 		{
 			Process: Process{},
@@ -46,7 +42,7 @@ func TestProcessTransform(t *testing.T) {
 				Pid:         123,
 				Ppid:        &ppid,
 				Title:       processTitle,
-				Argv:        argv,
+				Argv:        []string{"node", "server.js"},
 				CommandLine: commandLine,
 				Executable:  executablePath,
 				Thread: ProcessThread{
@@ -55,16 +51,16 @@ func TestProcessTransform(t *testing.T) {
 				},
 			},
 			Output: map[string]any{
-				"pid": 123,
+				"pid": 123.0,
 				"parent": map[string]any{
-					"pid": 456,
+					"pid": 456.0,
 				},
 				"title":        processTitle,
-				"args":         argv,
+				"args":         []any{"node", "server.js"},
 				"command_line": commandLine,
 				"executable":   executablePath,
 				"thread": map[string]any{
-					"id":   1,
+					"id":   1.0,
 					"name": "testThread",
 				},
 			},
@@ -72,7 +68,7 @@ func TestProcessTransform(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Process.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{Process: test.Process})
+		assert.Equal(t, test.Output, output["process"])
 	}
 }

--- a/model/spanlink_test.go
+++ b/model/spanlink_test.go
@@ -28,9 +28,6 @@ func TestSpanLinkFields(t *testing.T) {
 		Input    SpanLink
 		Expected map[string]any
 	}{{
-		Input:    SpanLink{},
-		Expected: nil,
-	}, {
 		Input: SpanLink{
 			Span: Span{ID: "span_id"},
 		},
@@ -55,7 +52,7 @@ func TestSpanLinkFields(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
-		output := test.Input.fields()
-		assert.Equal(t, test.Expected, output)
+		output := transformAPMEvent(APMEvent{Span: &Span{Links: []SpanLink{test.Input}}})
+		assert.Equal(t, []any{test.Expected}, output["span"].(map[string]any)["links"])
 	}
 }

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -31,7 +31,7 @@ func TestUserFields(t *testing.T) {
 
 	tests := []struct {
 		User   User
-		Output map[string]any
+		Output any
 	}{
 		{
 			User:   User{},
@@ -54,7 +54,7 @@ func TestUserFields(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.User.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{User: test.User})
+		assert.Equal(t, test.Output, output["user"])
 	}
 }

--- a/model/useragent_test.go
+++ b/model/useragent_test.go
@@ -26,7 +26,7 @@ import (
 func TestUserAgentFields(t *testing.T) {
 	tests := []struct {
 		UserAgent UserAgent
-		Output    map[string]any
+		Output    any
 	}{{
 		UserAgent: UserAgent{},
 		Output:    nil,
@@ -39,7 +39,7 @@ func TestUserAgentFields(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		output := test.UserAgent.fields()
-		assert.Equal(t, test.Output, output)
+		output := transformAPMEvent(APMEvent{UserAgent: test.UserAgent})
+		assert.Equal(t, test.Output, output["user_agent"])
 	}
 }


### PR DESCRIPTION
Update tests to use the `transformAPMEvent` function, which does a round-trip through JSON encoding/decoding.

This will enable us to refactor how the JSON encoding is performed, and stop tying us to the "fields" methods.