### PR TITLE
feat: drop sjson dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.63.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
-	github.com/tidwall/sjson v1.2.5
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.elastic.co/apm/v2 v2.2.0
 	go.elastic.co/fastjson v1.1.0
@@ -41,9 +40,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
-	github.com/tidwall/gjson v1.14.2 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,14 +81,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
-github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
-github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/model/host_test.go
+++ b/model/host_test.go
@@ -20,13 +20,14 @@ package model
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tidwall/sjson"
 )
 
 func TestHost(t *testing.T) {
 	out := marshalJSONAPMEvent(APMEvent{
+		Timestamp: time.Time{},
 		Host: Host{
 			Hostname:     "host_hostname",
 			Name:         "host_name",
@@ -45,9 +46,8 @@ func TestHost(t *testing.T) {
 			},
 		},
 	})
-	out, _ = sjson.DeleteBytes(out, "\\@timestamp")
 
-	assert.JSONEq(t, `{"host":{
+	assert.JSONEq(t, `{"@timestamp":"0001-01-01T00:00:00.000Z","host":{
 		"hostname": "host_hostname",
 		"name": "host_name",
 		"architecture": "amd",

--- a/model/transaction_test.go
+++ b/model/transaction_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tidwall/sjson"
 )
 
 func TestTransactionTransform(t *testing.T) {
@@ -268,16 +267,18 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 }
 
 func TestTransactionTransformMarks(t *testing.T) {
-	out := marshalJSONAPMEvent(APMEvent{Transaction: &Transaction{
-		Marks: TransactionMarks{
-			"a.b": TransactionMark{
-				"c.d": 123,
+	out := marshalJSONAPMEvent(APMEvent{
+		Timestamp: time.Time{},
+		Transaction: &Transaction{
+			Marks: TransactionMarks{
+				"a.b": TransactionMark{
+					"c.d": 123,
+				},
 			},
 		},
-	}})
-	out, _ = sjson.DeleteBytes(out, "\\@timestamp")
+	})
 
-	assert.JSONEq(t, `{"transaction":{
+	assert.JSONEq(t, `{"@timestamp":"0001-01-01T00:00:00.000Z","transaction":{
 		"marks": {
 		  "a_b": {
 		    "c_d": 123


### PR DESCRIPTION
> The zero value of type Time is January 1, year 1, 00:00:00.000000000 UTC.

See https://pkg.go.dev/time#Time

Since the value is deterministic we can just set it explicitly and account for it in the final comparison. 

Remove github.com/tidwall/sjson dependency (only used in tests)

~EDIT: apm-queue systemtest are still running :smiling_face_with_tear:~