### PR TITLE
feat: introduce protobuf definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         if [ -n "$(git status --porcelain)" ]; then
           echo 'Updates required:'
-          git status
+          git diff
           exit 1
         fi
 

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,5 @@ fieldalignment:
 	go run golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@v0.4.0 -test=false $(shell go list ./... | grep -v modeldecoder/generator | grep -v test)
 
 update-licenses:
-	go run github.com/elastic/go-licenser@v0.4.1 .
+	go run github.com/elastic/go-licenser@v0.4.1 -ext .go .
+	go run github.com/elastic/go-licenser@v0.4.1 -ext .proto .

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/tools v0.6.0
 	google.golang.org/grpc v1.54.0
+	google.golang.org/protobuf v1.30.0
 )
 
 require (
@@ -51,7 +52,6 @@ require (
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -33,13 +33,12 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/jcchavezs/porto v0.1.0 // indirect
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.63.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/procfs v0.9.0 // indirect
+	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/tools v0.6.0
 	google.golang.org/grpc v1.54.0
-	google.golang.org/protobuf v1.30.0
 )
 
 require (
@@ -51,6 +50,7 @@ require (
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,6 @@ github.com/apache/thrift v0.17.0/go.mod h1:OLxhMRJxomX+1I/KUw03qoV3mMz16BwaKI+d4
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -39,12 +38,10 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -56,7 +53,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger 
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.63.0/go.mod h1:w5rHiSvZJ110BJE/xLQxtlCGEELhfJ46dPR7XAHBXHE=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -65,10 +61,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
-github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
+github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
+github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEAh98m0=
 github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKPXCfD2aieJis=
 github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/model/labels.go
+++ b/model/labels.go
@@ -74,11 +74,11 @@ type NumericLabels map[string]NumericLabelValue
 // key. Only one should be set, in cases where both are set, the `Values` field
 // will be used and `Value` will be ignored.
 type NumericLabelValue struct {
-	// Value holds the label `float64` value.
-	Value float64
-
 	// Values holds holds the label `[]float64` value.
 	Values []float64
+
+	// Value holds the label `float64` value.
+	Value float64
 
 	// Global is `true` when the label is defined at the agent level, rather
 	// than being event-specific.

--- a/model/labels.go
+++ b/model/labels.go
@@ -74,11 +74,11 @@ type NumericLabels map[string]NumericLabelValue
 // key. Only one should be set, in cases where both are set, the `Values` field
 // will be used and `Value` will be ignored.
 type NumericLabelValue struct {
-	// Values holds holds the label `[]float64` value.
-	Values []float64
-
 	// Value holds the label `float64` value.
 	Value float64
+
+	// Values holds holds the label `[]float64` value.
+	Values []float64
 
 	// Global is `true` when the label is defined at the agent level, rather
 	// than being event-specific.

--- a/model/proto/agent.proto
+++ b/model/proto/agent.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Agent {
   string name = 1;

--- a/model/proto/agent.proto
+++ b/model/proto/agent.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Agent {
+  string name = 1;
+  string version = 2;
+  string ephemeral_id = 3;
+  string activation_method = 4;
+}

--- a/model/proto/agent.proto
+++ b/model/proto/agent.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/agent.proto
+++ b/model/proto/agent.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Agent {
   string name = 1;

--- a/model/proto/apmevent.proto
+++ b/model/proto/apmevent.proto
@@ -1,0 +1,78 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "google/protobuf/timestamp.proto";
+
+import "agent.proto";
+import "child.proto";
+import "client.proto";
+import "cloud.proto";
+import "container.proto";
+import "datastream.proto";
+import "destination.proto";
+import "device.proto";
+import "error.proto";
+import "event.proto";
+import "faas.proto";
+import "host.proto";
+import "http.proto";
+import "kubernetes.proto";
+import "labels.proto";
+import "log.proto";
+import "metricset.proto";
+import "network.proto";
+import "observer.proto";
+import "parent.proto";
+import "process.proto";
+import "processor.proto";
+import "service.proto";
+import "session.proto";
+import "source.proto";
+import "span.proto";
+import "trace.proto";
+import "transaction.proto";
+import "url.proto";
+import "user.proto";
+import "useragent.proto";
+
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message APMEvent {
+  google.protobuf.Timestamp timestamp = 1;
+  optional Span span = 2;
+  map<string, NumericLabelValue> numeric_labels = 3;
+  map<string, LabelValue> labels = 4;
+  optional Transaction transaction = 5;
+  optional Metricset metricset = 6;
+  optional Error error = 7;
+  Cloud cloud = 8;
+  Service service = 9;
+  Faas faas = 10;
+  Network network = 11;
+  Container container = 12;
+  User user = 13;
+  Device device = 14;
+  Kubernetes kubernetes = 15;
+  Observer    observer = 16;
+  DataStream data_stream =  17;
+  Agent      agent = 18;
+  Processor  processor = 19;
+  HTTP       http = 20;
+  UserAgent  user_agent = 21;
+  Parent     parent = 22;
+  string  message = 23;
+  Trace       trace = 24;
+  Host        host = 25;
+  URL         url = 26;
+  Log         log = 27;
+  Source      source = 28;
+  Client      client = 29;
+  Child       child = 30;
+  Destination destination = 31;
+  Session     session = 32;
+  Process     process = 33;
+  Event       event = 34;
+}

--- a/model/proto/apmevent.proto
+++ b/model/proto/apmevent.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-import "google/protobuf/timestamp.proto";
-
 import "agent.proto";
 import "child.proto";
 import "client.proto";
@@ -15,6 +13,7 @@ import "device.proto";
 import "error.proto";
 import "event.proto";
 import "faas.proto";
+import "google/protobuf/timestamp.proto";
 import "host.proto";
 import "http.proto";
 import "kubernetes.proto";
@@ -36,7 +35,6 @@ import "url.proto";
 import "user.proto";
 import "useragent.proto";
 
-
 option go_package = "/modelpb";
 option optimize_for = SPEED;
 
@@ -56,23 +54,23 @@ message APMEvent {
   User user = 13;
   Device device = 14;
   Kubernetes kubernetes = 15;
-  Observer    observer = 16;
-  DataStream data_stream =  17;
-  Agent      agent = 18;
-  Processor  processor = 19;
-  HTTP       http = 20;
-  UserAgent  user_agent = 21;
-  Parent     parent = 22;
-  string  message = 23;
-  Trace       trace = 24;
-  Host        host = 25;
-  URL         url = 26;
-  Log         log = 27;
-  Source      source = 28;
-  Client      client = 29;
-  Child       child = 30;
+  Observer observer = 16;
+  DataStream data_stream = 17;
+  Agent agent = 18;
+  Processor processor = 19;
+  HTTP http = 20;
+  UserAgent user_agent = 21;
+  Parent parent = 22;
+  string message = 23;
+  Trace trace = 24;
+  Host host = 25;
+  URL url = 26;
+  Log log = 27;
+  Source source = 28;
+  Client client = 29;
+  Child child = 30;
   Destination destination = 31;
-  Session     session = 32;
-  Process     process = 33;
-  Event       event = 34;
+  Session session = 32;
+  Process process = 33;
+  Event event = 34;
 }

--- a/model/proto/apmevent.proto
+++ b/model/proto/apmevent.proto
@@ -39,12 +39,12 @@ option go_package = "/modelpb";
 
 message APMEvent {
   google.protobuf.Timestamp timestamp = 1;
-  optional Span span = 2;
+  Span span = 2;
   map<string, NumericLabelValue> numeric_labels = 3;
   map<string, LabelValue> labels = 4;
-  optional Transaction transaction = 5;
-  optional Metricset metricset = 6;
-  optional Error error = 7;
+  Transaction transaction = 5;
+  Metricset metricset = 6;
+  Error error = 7;
   Cloud cloud = 8;
   Service service = 9;
   Faas faas = 10;

--- a/model/proto/apmevent.proto
+++ b/model/proto/apmevent.proto
@@ -35,7 +35,7 @@ import "url.proto";
 import "user.proto";
 import "useragent.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message APMEvent {
   google.protobuf.Timestamp timestamp = 1;

--- a/model/proto/apmevent.proto
+++ b/model/proto/apmevent.proto
@@ -36,7 +36,6 @@ import "user.proto";
 import "useragent.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message APMEvent {
   google.protobuf.Timestamp timestamp = 1;

--- a/model/proto/apmevent.proto
+++ b/model/proto/apmevent.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/child.proto
+++ b/model/proto/child.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Child {
+  repeated string id = 1;
+}

--- a/model/proto/child.proto
+++ b/model/proto/child.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Child {
   repeated string id = 1;

--- a/model/proto/child.proto
+++ b/model/proto/child.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/child.proto
+++ b/model/proto/child.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Child {
   repeated string id = 1;

--- a/model/proto/client.proto
+++ b/model/proto/client.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Client {
+  string ip = 1;
+  string domain = 2;
+  uint32 port = 3;
+}

--- a/model/proto/client.proto
+++ b/model/proto/client.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Client {
   string ip = 1;

--- a/model/proto/client.proto
+++ b/model/proto/client.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/client.proto
+++ b/model/proto/client.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Client {
   string ip = 1;

--- a/model/proto/cloud.proto
+++ b/model/proto/cloud.proto
@@ -5,7 +5,7 @@ package elastic.apm.v1;
 option go_package = "/modelpb";
 
 message Cloud {
-  optional CloudOrigin origin = 1;
+  CloudOrigin origin = 1;
   string account_id = 2;
   string account_name = 3;
   string availability_zone = 4;

--- a/model/proto/cloud.proto
+++ b/model/proto/cloud.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Cloud {
   CloudOrigin origin = 1;

--- a/model/proto/cloud.proto
+++ b/model/proto/cloud.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/cloud.proto
+++ b/model/proto/cloud.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Cloud {
   optional CloudOrigin origin = 1;

--- a/model/proto/cloud.proto
+++ b/model/proto/cloud.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Cloud {
+  optional CloudOrigin origin = 1;
+  string account_id = 2;
+  string account_name = 3;
+  string availability_zone = 4;
+  string instance_id = 5;
+  string instance_name = 6;
+  string machine_type = 7;
+  string project_id = 8;
+  string project_name = 9;
+  string provider = 10;
+  string region = 11;
+  string service_name = 12;
+}
+
+message CloudOrigin {
+  string account_id = 1;
+  string provider = 2;
+  string region = 3;
+  string service_name = 4;
+}

--- a/model/proto/container.proto
+++ b/model/proto/container.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Container {
   string id = 1;

--- a/model/proto/container.proto
+++ b/model/proto/container.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/container.proto
+++ b/model/proto/container.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Container {
   string id = 1;

--- a/model/proto/container.proto
+++ b/model/proto/container.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Container {
+  string id = 1;
+  string name = 2;
+  string runtime = 3;
+  string image_name = 4;
+  string image_tag = 5;
+}

--- a/model/proto/datastream.proto
+++ b/model/proto/datastream.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message DataStream {
   string type = 1;

--- a/model/proto/datastream.proto
+++ b/model/proto/datastream.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/datastream.proto
+++ b/model/proto/datastream.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message DataStream {
+  string type = 1;
+  string dataset = 2;
+  string namespace = 3;
+}

--- a/model/proto/datastream.proto
+++ b/model/proto/datastream.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message DataStream {
   string type = 1;

--- a/model/proto/destination.proto
+++ b/model/proto/destination.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Destination {
   string address = 1;

--- a/model/proto/destination.proto
+++ b/model/proto/destination.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Destination {
+  string address = 1;
+  uint32 port = 2;
+}

--- a/model/proto/destination.proto
+++ b/model/proto/destination.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Destination {
   string address = 1;

--- a/model/proto/destination.proto
+++ b/model/proto/destination.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/device.proto
+++ b/model/proto/device.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Device {
   string id = 1;

--- a/model/proto/device.proto
+++ b/model/proto/device.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Device {
   string id = 1;

--- a/model/proto/device.proto
+++ b/model/proto/device.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Device {
+  string id = 1;
+  DeviceModel model = 2;
+  string manufacturer = 3;
+}
+
+message DeviceModel {
+  string name = 1;
+  string identifier = 2;
+}

--- a/model/proto/device.proto
+++ b/model/proto/device.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/error.proto
+++ b/model/proto/error.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "google/protobuf/struct.proto";
+import "stacktrace.proto";
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Error {
+  google.protobuf.Struct custom = 1;
+  optional Exception exception = 2;
+  optional ErrorLog log = 3;
+  string id = 4;
+  string grouping_key = 5;
+  string culprit = 6;
+  string stack_trace = 7;
+  string message = 8;
+  string type = 9;
+}
+
+message Exception {
+  string message = 1;
+  string module = 2;
+  string code = 3;
+  google.protobuf.Struct attributes = 4;
+  repeated StacktraceFrame stacktrace = 5;
+  string type = 6;
+  optional bool handled = 7;
+  repeated Exception cause = 8;
+}
+
+message ErrorLog {
+  string message = 1;
+  string level = 2;
+  string param_message = 3;
+  string logger_name = 4;
+  repeated StacktraceFrame stacktrace = 5;
+}

--- a/model/proto/error.proto
+++ b/model/proto/error.proto
@@ -6,7 +6,6 @@ import "google/protobuf/struct.proto";
 import "stacktrace.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Error {
   google.protobuf.Struct custom = 1;

--- a/model/proto/error.proto
+++ b/model/proto/error.proto
@@ -5,7 +5,7 @@ package elastic.apm.v1;
 import "google/protobuf/struct.proto";
 import "stacktrace.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Error {
   google.protobuf.Struct custom = 1;

--- a/model/proto/error.proto
+++ b/model/proto/error.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/error.proto
+++ b/model/proto/error.proto
@@ -9,8 +9,8 @@ option go_package = "/modelpb";
 
 message Error {
   google.protobuf.Struct custom = 1;
-  optional Exception exception = 2;
-  optional ErrorLog log = 3;
+  Exception exception = 2;
+  ErrorLog log = 3;
   string id = 4;
   string grouping_key = 5;
   string culprit = 6;

--- a/model/proto/event.proto
+++ b/model/proto/event.proto
@@ -6,7 +6,6 @@ import "google/protobuf/duration.proto";
 import "metricset.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Event {
   string outcome = 1;

--- a/model/proto/event.proto
+++ b/model/proto/event.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/event.proto
+++ b/model/proto/event.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "google/protobuf/duration.proto";
+
+import "metricset.proto";
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Event {
+  string outcome = 1;
+  string action = 2;
+  string dataset = 3;
+
+  string kind = 4;
+  string category = 5;
+  string type = 6;
+
+  SummaryMetric success_count = 7;
+  google.protobuf.Duration duration = 8;
+  int64 severity = 9;
+}

--- a/model/proto/event.proto
+++ b/model/proto/event.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 import "google/protobuf/duration.proto";
-
 import "metricset.proto";
 
 option go_package = "/modelpb";

--- a/model/proto/event.proto
+++ b/model/proto/event.proto
@@ -5,7 +5,7 @@ package elastic.apm.v1;
 import "google/protobuf/duration.proto";
 import "metricset.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Event {
   string outcome = 1;

--- a/model/proto/experience.proto
+++ b/model/proto/experience.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message UserExperience {
+  double cumulative_layout_shift = 1;
+  double first_input_delay = 2;
+  double total_blocking_time = 3;
+  LongtaskMetrics long_task = 4;
+}
+
+message LongtaskMetrics {
+  int64 count = 1;
+  double sum = 2;
+  double max = 3;
+}

--- a/model/proto/experience.proto
+++ b/model/proto/experience.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/experience.proto
+++ b/model/proto/experience.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message UserExperience {
   double cumulative_layout_shift = 1;

--- a/model/proto/experience.proto
+++ b/model/proto/experience.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message UserExperience {
   double cumulative_layout_shift = 1;

--- a/model/proto/faas.proto
+++ b/model/proto/faas.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Faas {
   string id = 1;

--- a/model/proto/faas.proto
+++ b/model/proto/faas.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Faas {
   string id = 1;

--- a/model/proto/faas.proto
+++ b/model/proto/faas.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Faas {
+  string id = 1;
+  optional bool cold_start = 2;
+  string execution = 3;
+  string trigger_type = 4;
+  string trigger_request_id = 5;
+  string name = 6;
+  string version = 7;
+}

--- a/model/proto/faas.proto
+++ b/model/proto/faas.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/host.proto
+++ b/model/proto/host.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "os.proto";
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Host {
+  OS os = 1;
+  string hostname = 2;
+  string name = 3;
+  string id = 4;
+  string architecture = 5;
+  string type = 6;
+  repeated string ip = 7;
+}

--- a/model/proto/host.proto
+++ b/model/proto/host.proto
@@ -5,7 +5,6 @@ package elastic.apm.v1;
 import "os.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Host {
   OS os = 1;

--- a/model/proto/host.proto
+++ b/model/proto/host.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/host.proto
+++ b/model/proto/host.proto
@@ -4,7 +4,7 @@ package elastic.apm.v1;
 
 import "os.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Host {
   OS os = 1;

--- a/model/proto/http.proto
+++ b/model/proto/http.proto
@@ -5,7 +5,6 @@ package elastic.apm.v1;
 import "google/protobuf/struct.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message HTTP {
   optional HTTPRequest request = 1;

--- a/model/proto/http.proto
+++ b/model/proto/http.proto
@@ -7,8 +7,8 @@ import "google/protobuf/struct.proto";
 option go_package = "/modelpb";
 
 message HTTP {
-  optional HTTPRequest request = 1;
-  optional HTTPResponse response = 2;
+  HTTPRequest request = 1;
+  HTTPResponse response = 2;
   string version = 3;
 }
 

--- a/model/proto/http.proto
+++ b/model/proto/http.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/http.proto
+++ b/model/proto/http.proto
@@ -4,7 +4,7 @@ package elastic.apm.v1;
 
 import "google/protobuf/struct.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message HTTP {
   HTTPRequest request = 1;

--- a/model/proto/http.proto
+++ b/model/proto/http.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "google/protobuf/struct.proto";
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message HTTP {
+  optional HTTPRequest request = 1;
+  optional HTTPResponse response = 2;
+  string version = 3;
+}
+
+message HTTPRequest {
+  google.protobuf.Struct body = 1;
+  google.protobuf.Struct headers = 2;
+  google.protobuf.Struct env = 3;
+  google.protobuf.Struct cookies = 4;
+  string id = 5;
+  string method = 6;
+  string referrer = 7;
+}
+
+message HTTPResponse {
+  google.protobuf.Struct headers = 1;
+  optional bool finished = 2;
+  optional bool headers_sent = 3;
+  optional int64 transfer_size = 4;
+  optional int64 encoded_body_size = 5;
+  optional int64 decoded_body_size = 6;
+  int32 status_code = 7;
+}

--- a/model/proto/kubernetes.proto
+++ b/model/proto/kubernetes.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Kubernetes {
   string namespace = 1;

--- a/model/proto/kubernetes.proto
+++ b/model/proto/kubernetes.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/kubernetes.proto
+++ b/model/proto/kubernetes.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Kubernetes {
   string namespace = 1;

--- a/model/proto/kubernetes.proto
+++ b/model/proto/kubernetes.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Kubernetes {
+  string namespace = 1;
+  string node_name = 2;
+  string pod_name = 3;
+  string pod_uid = 4;
+}

--- a/model/proto/labels.proto
+++ b/model/proto/labels.proto
@@ -12,7 +12,7 @@ message LabelValue {
 }
 
 message NumericLabelValue {
-  double value = 1;
-  repeated double values = 2;
+  repeated double values = 1;
+  double value = 2;
   bool global = 3;
 }

--- a/model/proto/labels.proto
+++ b/model/proto/labels.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message LabelValue {
+  string value = 1;
+  repeated string values = 2;
+  bool global = 3;
+}
+
+message NumericLabelValue {
+  double value = 1;
+  repeated double values = 2;
+  bool global = 3;
+}

--- a/model/proto/labels.proto
+++ b/model/proto/labels.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message LabelValue {
   string value = 1;

--- a/model/proto/labels.proto
+++ b/model/proto/labels.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message LabelValue {
   string value = 1;

--- a/model/proto/labels.proto
+++ b/model/proto/labels.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/log.proto
+++ b/model/proto/log.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Log {
+  string level = 1;
+  string logger = 2;
+  LogOrigin origin = 3;
+}
+
+message LogOrigin {
+  string function_name= 1;
+  LogOriginFile file = 2;
+}
+
+message LogOriginFile {
+  string name = 1;
+  int32 line = 2;
+}

--- a/model/proto/log.proto
+++ b/model/proto/log.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Log {
   string level = 1;

--- a/model/proto/log.proto
+++ b/model/proto/log.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/log.proto
+++ b/model/proto/log.proto
@@ -12,7 +12,7 @@ message Log {
 }
 
 message LogOrigin {
-  string function_name= 1;
+  string function_name = 1;
   LogOriginFile file = 2;
 }
 

--- a/model/proto/log.proto
+++ b/model/proto/log.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Log {
   string level = 1;

--- a/model/proto/message.proto
+++ b/model/proto/message.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Message {
   string body = 1;

--- a/model/proto/message.proto
+++ b/model/proto/message.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/message.proto
+++ b/model/proto/message.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Message {
   string body = 1;

--- a/model/proto/message.proto
+++ b/model/proto/message.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Message {
+  string body = 1;
+  map<string, HTTPHeaderValue> headers = 2;
+  optional int64 age_millis = 3;
+  string queue_name = 4;
+  string routing_key = 5;
+}
+
+message HTTPHeaderValue {
+  repeated string values = 1;
+}

--- a/model/proto/metricset.proto
+++ b/model/proto/metricset.proto
@@ -5,7 +5,6 @@ package elastic.apm.v1;
 import "google/protobuf/duration.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Metricset {
   string name = 1;

--- a/model/proto/metricset.proto
+++ b/model/proto/metricset.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "google/protobuf/duration.proto";
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Metricset {
+  string name = 1;
+  string interval = 2;
+  repeated MetricsetSample samples = 3;
+  int64 doc_count = 4;
+}
+
+enum MetricType {
+  METRIC_TYPE_UNSPECIFIED = 0;
+  METRIC_TYPE_GAUGE = 1;
+  METRIC_TYPE_COUNTER = 2;
+  METRIC_TYPE_HISTOGRAM = 3;
+  METRIC_TYPE_SUMMARY = 4;
+}
+
+message MetricsetSample {
+  MetricType type = 1;
+  string name = 2;
+  string unit = 3;
+  Histogram histogram = 4;
+  SummaryMetric summary = 5;
+  double value = 6;
+}
+
+message Histogram {
+  repeated double values = 1;
+  repeated int64 counts = 2;
+}
+
+message SummaryMetric {
+  int64 count = 1;
+  double sum = 2;
+}
+
+message AggregatedDuration {
+  int64 count = 1;
+  google.protobuf.Duration sum = 5;
+}

--- a/model/proto/metricset.proto
+++ b/model/proto/metricset.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/metricset.proto
+++ b/model/proto/metricset.proto
@@ -42,5 +42,5 @@ message SummaryMetric {
 
 message AggregatedDuration {
   int64 count = 1;
-  google.protobuf.Duration sum = 5;
+  google.protobuf.Duration sum = 2;
 }

--- a/model/proto/metricset.proto
+++ b/model/proto/metricset.proto
@@ -4,7 +4,7 @@ package elastic.apm.v1;
 
 import "google/protobuf/duration.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Metricset {
   string name = 1;

--- a/model/proto/network.proto
+++ b/model/proto/network.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Network {
   NetworkConnection connection = 1;

--- a/model/proto/network.proto
+++ b/model/proto/network.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Network {
+  NetworkConnection connection = 1;
+  NetworkCarrier carrier = 2;
+}
+
+message NetworkConnection {
+  string type = 1;
+  string subtype = 2;
+}
+
+message NetworkCarrier {
+  string name = 1;
+  string mcc = 2;
+  string mnc = 3;
+  string icc = 4;
+}

--- a/model/proto/network.proto
+++ b/model/proto/network.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Network {
   NetworkConnection connection = 1;

--- a/model/proto/network.proto
+++ b/model/proto/network.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/observer.proto
+++ b/model/proto/observer.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Observer {
   string hostname = 1;

--- a/model/proto/observer.proto
+++ b/model/proto/observer.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Observer {
+  string hostname = 1;
+  string name = 2;
+  string type = 3;
+  string version = 4;
+}

--- a/model/proto/observer.proto
+++ b/model/proto/observer.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Observer {
   string hostname = 1;

--- a/model/proto/observer.proto
+++ b/model/proto/observer.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/os.proto
+++ b/model/proto/os.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message OS {
+  string name = 1;
+  string version = 2;
+  string platform = 3;
+  string full = 4;
+  string type = 5;
+}

--- a/model/proto/os.proto
+++ b/model/proto/os.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message OS {
   string name = 1;

--- a/model/proto/os.proto
+++ b/model/proto/os.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/os.proto
+++ b/model/proto/os.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message OS {
   string name = 1;

--- a/model/proto/parent.proto
+++ b/model/proto/parent.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Parent {
   string id = 1;

--- a/model/proto/parent.proto
+++ b/model/proto/parent.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/parent.proto
+++ b/model/proto/parent.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Parent {
+  string id = 1;
+}

--- a/model/proto/parent.proto
+++ b/model/proto/parent.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Parent {
   string id = 1;

--- a/model/proto/process.proto
+++ b/model/proto/process.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Process {
   optional uint32 ppid = 1;

--- a/model/proto/process.proto
+++ b/model/proto/process.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Process {
   optional uint32 ppid = 1;

--- a/model/proto/process.proto
+++ b/model/proto/process.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Process {
+  optional uint32 ppid = 1;
+  ProcessThread thread = 2;
+  string title = 3;
+  string command_line = 4;
+  string executable = 5;
+  repeated string argv = 6;
+  uint32 pid = 7;
+}
+
+message ProcessThread {
+  string name = 1;
+  int32 id = 2;
+}

--- a/model/proto/process.proto
+++ b/model/proto/process.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/processor.proto
+++ b/model/proto/processor.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Processor {
   string name = 1;

--- a/model/proto/processor.proto
+++ b/model/proto/processor.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/processor.proto
+++ b/model/proto/processor.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Processor {
+  string name = 1;
+  string event = 2;
+}

--- a/model/proto/processor.proto
+++ b/model/proto/processor.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Processor {
   string name = 1;

--- a/model/proto/service.proto
+++ b/model/proto/service.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Service {
   optional ServiceOrigin origin = 1;

--- a/model/proto/service.proto
+++ b/model/proto/service.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Service {
+  optional ServiceOrigin origin = 1;
+  optional ServiceTarget target = 2;
+  Language language = 3;
+  Runtime runtime = 4;
+  Framework framework = 5;
+  string name = 6;
+  string version = 7;
+  string environment = 8;
+  ServiceNode node = 9;
+}
+
+message ServiceOrigin {
+  string id = 1;
+  string name = 2;
+  string version = 3;
+}
+
+message ServiceTarget {
+  string name = 1;
+  string type = 2;
+}
+
+message Language { 
+  string name = 1;
+  string version = 2;
+}
+
+message Runtime {
+  string name = 1;
+  string version = 2;
+}
+
+message Framework {
+  string name = 1;
+  string version = 2;
+}
+
+message ServiceNode {
+  string name = 1;
+}

--- a/model/proto/service.proto
+++ b/model/proto/service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Service {
   ServiceOrigin origin = 1;

--- a/model/proto/service.proto
+++ b/model/proto/service.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/service.proto
+++ b/model/proto/service.proto
@@ -28,7 +28,7 @@ message ServiceTarget {
   string type = 2;
 }
 
-message Language { 
+message Language {
   string name = 1;
   string version = 2;
 }

--- a/model/proto/service.proto
+++ b/model/proto/service.proto
@@ -5,8 +5,8 @@ package elastic.apm.v1;
 option go_package = "/modelpb";
 
 message Service {
-  optional ServiceOrigin origin = 1;
-  optional ServiceTarget target = 2;
+  ServiceOrigin origin = 1;
+  ServiceTarget target = 2;
   Language language = 3;
   Runtime runtime = 4;
   Framework framework = 5;

--- a/model/proto/session.proto
+++ b/model/proto/session.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Session {
   string id = 1;

--- a/model/proto/session.proto
+++ b/model/proto/session.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Session {
+  string id = 1;
+  int64 sequence = 2;
+}

--- a/model/proto/session.proto
+++ b/model/proto/session.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/session.proto
+++ b/model/proto/session.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Session {
   string id = 1;

--- a/model/proto/source.proto
+++ b/model/proto/source.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Source {
   string ip = 1;

--- a/model/proto/source.proto
+++ b/model/proto/source.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Source {
+  string ip = 1;
+  NAT nat = 2;
+  string domain = 3;
+  uint32 port = 4;
+}
+
+message NAT {
+  string ip = 1;
+}

--- a/model/proto/source.proto
+++ b/model/proto/source.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/source.proto
+++ b/model/proto/source.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Source {
   string ip = 1;

--- a/model/proto/span.proto
+++ b/model/proto/span.proto
@@ -8,7 +8,6 @@ import "stacktrace.proto";
 import "trace.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Span {
   optional Message message = 1;

--- a/model/proto/span.proto
+++ b/model/proto/span.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/span.proto
+++ b/model/proto/span.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "message.proto";
+import "metricset.proto";
+import "stacktrace.proto";
+import "trace.proto";
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Span {
+  optional Message message = 1;
+  optional Composite composite = 2;
+  optional DestinationService destination_service = 3;
+  optional DB db = 4;
+  optional bool sync = 5;
+  string kind = 6;
+  string action = 7;
+  string subtype = 8;
+  string id = 9;
+  string type = 10;
+  string name = 11;
+  repeated StacktraceFrame stacktrace = 12;
+  repeated SpanLink links = 13;
+  AggregatedDuration self_time = 14;
+  double representative_count = 15;
+}
+
+message DB {
+  optional int64 rows_affected = 1;
+  string instance = 2;
+  string statement = 3;
+  string type = 4;
+  string user_name = 5;
+  string link = 6;
+}
+
+message DestinationService {
+  string type = 1;
+  string name = 2;
+  string resource = 3;
+  AggregatedDuration response_time = 4;
+}
+
+enum CompressionStrategy {
+  COMPRESSION_STRATEGY_UNSPECIFIED = 0;
+  COMPRESSION_STRATEGY_EXACT_MATCH = 1;
+  COMPRESSION_STRATEGY_SAME_KIND = 2;
+}
+
+message Composite {
+  CompressionStrategy compression_strategy = 1;
+  uint32 count = 2;
+  double sum = 3;
+}
+
+message SpanLink {
+  Trace trace = 1;
+  Span span = 2;
+}

--- a/model/proto/span.proto
+++ b/model/proto/span.proto
@@ -10,10 +10,10 @@ import "trace.proto";
 option go_package = "/modelpb";
 
 message Span {
-  optional Message message = 1;
-  optional Composite composite = 2;
-  optional DestinationService destination_service = 3;
-  optional DB db = 4;
+  Message message = 1;
+  Composite composite = 2;
+  DestinationService destination_service = 3;
+  DB db = 4;
   optional bool sync = 5;
   string kind = 6;
   string action = 7;

--- a/model/proto/span.proto
+++ b/model/proto/span.proto
@@ -7,7 +7,7 @@ import "metricset.proto";
 import "stacktrace.proto";
 import "trace.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Span {
   Message message = 1;

--- a/model/proto/stacktrace.proto
+++ b/model/proto/stacktrace.proto
@@ -4,7 +4,7 @@ package elastic.apm.v1;
 
 import "google/protobuf/struct.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message StacktraceFrame {
   google.protobuf.Struct vars = 1;

--- a/model/proto/stacktrace.proto
+++ b/model/proto/stacktrace.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "google/protobuf/struct.proto";
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message StacktraceFrame {
+  google.protobuf.Struct vars = 1;
+  optional int32 lineno = 2;
+  optional int32 colno = 3;
+  string filename = 4;
+  string classname = 5;
+  string context_line = 6;
+  string module = 7;
+  string function = 8;
+  string abs_path = 9;
+  string sourcemap_error = 10;
+  Original original = 11;
+  repeated string pre_context = 12;
+  repeated string post_context = 13;
+  bool library_frame = 14;
+  bool sourcemap_updated = 15;
+  bool exclude_from_grouping = 16;
+}
+
+message Original {
+  string abs_path = 1;
+  string filename = 2;
+  string classname = 3;
+  optional int32 lineno = 4;
+  optional int32 colno = 5;
+  string function = 6;
+  bool library_frame = 7;
+}

--- a/model/proto/stacktrace.proto
+++ b/model/proto/stacktrace.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/stacktrace.proto
+++ b/model/proto/stacktrace.proto
@@ -5,7 +5,6 @@ package elastic.apm.v1;
 import "google/protobuf/struct.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message StacktraceFrame {
   google.protobuf.Struct vars = 1;

--- a/model/proto/trace.proto
+++ b/model/proto/trace.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Trace {
   string id = 1;

--- a/model/proto/trace.proto
+++ b/model/proto/trace.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Trace {
   string id = 1;

--- a/model/proto/trace.proto
+++ b/model/proto/trace.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/trace.proto
+++ b/model/proto/trace.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Trace {
+  string id = 1;
+}

--- a/model/proto/transaction.proto
+++ b/model/proto/transaction.proto
@@ -8,7 +8,6 @@ import "message.proto";
 import "metricset.proto";
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message Transaction {
   SpanCount span_count = 1;

--- a/model/proto/transaction.proto
+++ b/model/proto/transaction.proto
@@ -2,9 +2,8 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-import "google/protobuf/struct.proto";
-
 import "experience.proto";
+import "google/protobuf/struct.proto";
 import "message.proto";
 import "metricset.proto";
 

--- a/model/proto/transaction.proto
+++ b/model/proto/transaction.proto
@@ -11,10 +11,10 @@ option go_package = "/modelpb";
 
 message Transaction {
   SpanCount span_count = 1;
-  optional UserExperience user_experience = 2;
+  UserExperience user_experience = 2;
   google.protobuf.Struct custom = 3;
   map<string, TransactionMark> marks = 4;
-  optional Message message = 5;
+  Message message = 5;
   string type = 6;
   string name = 7;
   string result = 8;

--- a/model/proto/transaction.proto
+++ b/model/proto/transaction.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/transaction.proto
+++ b/model/proto/transaction.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+import "google/protobuf/struct.proto";
+
+import "experience.proto";
+import "message.proto";
+import "metricset.proto";
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message Transaction {
+  SpanCount span_count = 1;
+  optional UserExperience user_experience = 2;
+  google.protobuf.Struct custom = 3;
+  map<string, TransactionMark> marks = 4;
+  optional Message message = 5;
+  string type = 6;
+  string name = 7;
+  string result = 8;
+  string id = 9;
+  Histogram duration_histogram = 10;
+  repeated DroppedSpanStats dropped_spans_stats = 11;
+  SummaryMetric duration_summary = 12;
+  double representative_count = 13;
+  bool sampled = 14;
+  bool root = 15;
+}
+
+message SpanCount {
+  optional int64 dropped = 1;
+  optional int64 started = 2;
+}
+
+message TransactionMark {
+  map<string, double> measurements = 1;
+}
+
+message DroppedSpanStats {
+  string destination_service_resource = 1;
+  string service_target_type = 2;
+  string service_target_name = 3;
+  string outcome = 4;
+  AggregatedDuration duration = 5;
+}

--- a/model/proto/transaction.proto
+++ b/model/proto/transaction.proto
@@ -7,7 +7,7 @@ import "google/protobuf/struct.proto";
 import "message.proto";
 import "metricset.proto";
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message Transaction {
   SpanCount span_count = 1;

--- a/model/proto/url.proto
+++ b/model/proto/url.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message URL {
+  string original = 1;
+  string scheme = 2;
+  string full = 3;
+  string domain = 4;
+  string path = 5;
+  string query = 6;
+  string fragment = 7;
+  uint32 port = 8;
+}

--- a/model/proto/url.proto
+++ b/model/proto/url.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message URL {
   string original = 1;

--- a/model/proto/url.proto
+++ b/model/proto/url.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message URL {
   string original = 1;

--- a/model/proto/url.proto
+++ b/model/proto/url.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/user.proto
+++ b/model/proto/user.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message User {
+  string domain = 1;
+  string id = 2;
+  string email = 3;
+  string name = 4;
+}

--- a/model/proto/user.proto
+++ b/model/proto/user.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message User {
   string domain = 1;

--- a/model/proto/user.proto
+++ b/model/proto/user.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message User {
   string domain = 1;

--- a/model/proto/user.proto
+++ b/model/proto/user.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/useragent.proto
+++ b/model/proto/useragent.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package elastic.apm.v1;
+
+option go_package = "/modelpb";
+option optimize_for = SPEED;
+
+message UserAgent {
+  string original = 1;
+  string name = 2;
+}

--- a/model/proto/useragent.proto
+++ b/model/proto/useragent.proto
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 syntax = "proto3";
 
 package elastic.apm.v1;

--- a/model/proto/useragent.proto
+++ b/model/proto/useragent.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package elastic.apm.v1;
 
-option go_package = "/modelpb";
+option go_package = "github.com/elastic/apm-data/model/modelpb";
 
 message UserAgent {
   string original = 1;

--- a/model/proto/useragent.proto
+++ b/model/proto/useragent.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package elastic.apm.v1;
 
 option go_package = "/modelpb";
-option optimize_for = SPEED;
 
 message UserAgent {
   string original = 1;


### PR DESCRIPTION
Related to https://github.com/elastic/apm-data/issues/36

Should address step 1.

Introduce protobuf definitions based on model events.

The protobuf definitions are optimized for speed and they will be generated in a `modelpb` package.

Out of scope for this PR:
- comments (I want to add them once we remove APMEvent to avoid maintained two docs)
