### PR TITLE
Hide semaphore technical implementation, and use an interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0011
 	go.opentelemetry.io/collector/semconv v0.76.1
 	go.uber.org/zap v1.24.0
+	golang.org/x/sync v0.1.0
 	golang.org/x/tools v0.6.0
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/input/elasticapm/processor.go
+++ b/input/elasticapm/processor.go
@@ -28,6 +28,7 @@ import (
 	"go.elastic.co/apm/v2"
 	"go.uber.org/zap"
 
+	"github.com/elastic/apm-data/input"
 	"github.com/elastic/apm-data/input/elasticapm/internal/decoder"
 	"github.com/elastic/apm-data/input/elasticapm/internal/modeldecoder"
 	"github.com/elastic/apm-data/input/elasticapm/internal/modeldecoder/rumv3"
@@ -64,28 +65,21 @@ const (
 type Processor struct {
 	streamReaderPool sync.Pool
 	batchPool        sync.Pool
-	sem              chan struct{}
+	sem              input.Semaphore
 	logger           *zap.Logger
 	MaxEventSize     int
 }
 
 // Config holds configuration for Processor constructors.
 type Config struct {
-	// Semaphore holds a channel to which Processor.HandleStream
-	// will send an item before proceeding, to limit concurrency.
-	// Deprecated: use the MaxConcurrency value instead
-	Semaphore chan struct{}
-
+	// Semaphore holds a semaphore on which Processor.HandleStream will acquire a
+	// token before proceeding, to limit concurrency.
+	Semaphore input.Semaphore
 	// Logger holds a logger for the processor. If Logger is nil,
 	// then no logging will be performed.
 	Logger *zap.Logger
 	// MaxEventSize holds the maximum event size, in bytes.
 	MaxEventSize int
-
-	// MaxConcurrency hold the maximum number of running Processor.HandleStram
-	// that can run in parallel. The value is configured within the semaphore
-	// created on setup.
-	MaxConcurrency int64
 }
 
 // NewProcessor returns a new Processor for processing an event stream from
@@ -94,15 +88,9 @@ func NewProcessor(cfg Config) *Processor {
 	if cfg.Logger == nil {
 		cfg.Logger = zap.NewNop()
 	}
-
-	semaphore := cfg.Semaphore
-	if semaphore == nil {
-		semaphore = make(chan struct{}, cfg.MaxConcurrency)
-	}
-
 	return &Processor{
 		MaxEventSize: cfg.MaxEventSize,
-		sem:          semaphore,
+		sem:          cfg.Semaphore,
 		logger:       cfg.Logger,
 	}
 }
@@ -263,7 +251,7 @@ func (p *Processor) HandleStream(
 	defer func() {
 		sr.release()
 		if shouldReleaseSemaphore {
-			p.semRelease()
+			p.sem.Release(1)
 		}
 	}()
 
@@ -327,7 +315,7 @@ func (p *Processor) handleStream(
 			// If no events have been read on an asynchronous request, release
 			// the semaphore since the processing goroutine isn't scheduled.
 			if n == 0 {
-				p.semRelease()
+				p.sem.Release(1)
 			}
 		}()
 	}
@@ -345,7 +333,7 @@ func (p *Processor) handleStream(
 	// been processed, the semaphore is released.
 	if async {
 		go func() {
-			defer p.semRelease()
+			defer p.sem.Release(1)
 			if err := p.processBatch(ctx, processor, &batch); err != nil {
 				p.logger.Error("failed handling async request", zap.Error(err))
 			}
@@ -378,22 +366,14 @@ func (p *Processor) getStreamReader(r io.Reader) *streamReader {
 }
 
 func (p *Processor) semAcquire(ctx context.Context, async bool) error {
-	select {
-	case p.sem <- struct{}{}:
-	default:
-		if async {
+	if async {
+		if ok := p.sem.TryAcquire(1); !ok {
 			return ErrQueueFull
 		}
-		select {
-		case p.sem <- struct{}{}:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		return nil
 	}
-	return nil
+	return p.sem.Acquire(ctx, 1)
 }
-
-func (p *Processor) semRelease() { <-p.sem }
 
 // streamReader wraps NDJSONStreamReader, converting errors to stream errors.
 type streamReader struct {

--- a/input/elasticapm/processor_test.go
+++ b/input/elasticapm/processor_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/elastic/apm-data/model"
 )
@@ -51,8 +52,8 @@ func TestHandleStreamReaderError(t *testing.T) {
 	}
 
 	sp := NewProcessor(Config{
-		MaxEventSize:   100 * 1024,
-		MaxConcurrency: 1,
+		MaxEventSize: 100 * 1024,
+		Semaphore:    semaphore.NewWeighted(1),
 	})
 
 	var actualResult Result
@@ -83,8 +84,8 @@ func TestHandleStreamBatchProcessorError(t *testing.T) {
 		err:  ErrQueueFull,
 	}} {
 		sp := NewProcessor(Config{
-			MaxEventSize:   100 * 1024,
-			MaxConcurrency: 1,
+			MaxEventSize: 100 * 1024,
+			Semaphore:    semaphore.NewWeighted(1),
 		})
 		processor := model.ProcessBatchFunc(func(context.Context, *model.Batch) error {
 			return test.err
@@ -184,8 +185,8 @@ func TestHandleStreamErrors(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var actualResult Result
 			p := NewProcessor(Config{
-				MaxEventSize:   len(validMetadata) + 1,
-				MaxConcurrency: 1,
+				MaxEventSize: len(validMetadata) + 1,
+				Semaphore:    semaphore.NewWeighted(1),
 			})
 			err := p.HandleStream(
 				context.Background(), false, model.APMEvent{},
@@ -219,8 +220,8 @@ func TestHandleStream(t *testing.T) {
 	}, "\n")
 
 	p := NewProcessor(Config{
-		MaxEventSize:   100 * 1024,
-		MaxConcurrency: 1,
+		MaxEventSize: 100 * 1024,
+		Semaphore:    semaphore.NewWeighted(1),
 	})
 	err := p.HandleStream(
 		context.Background(), false, model.APMEvent{},
@@ -257,8 +258,8 @@ func TestHandleStreamRUMv3(t *testing.T) {
 	}, "\n")
 
 	p := NewProcessor(Config{
-		MaxEventSize:   100 * 1024,
-		MaxConcurrency: 1,
+		MaxEventSize: 100 * 1024,
+		Semaphore:    semaphore.NewWeighted(1),
 	})
 	err := p.HandleStream(
 		context.Background(), false, model.APMEvent{},
@@ -305,8 +306,8 @@ func TestHandleStreamBaseEvent(t *testing.T) {
 
 	payload := validMetadata + "\n" + validRUMv2Span + "\n"
 	p := NewProcessor(Config{
-		MaxEventSize:   100 * 1024,
-		MaxConcurrency: 1,
+		MaxEventSize: 100 * 1024,
+		Semaphore:    semaphore.NewWeighted(1),
 	})
 	err := p.HandleStream(
 		context.Background(), false, baseEvent,
@@ -338,8 +339,8 @@ func TestLabelLeak(t *testing.T) {
 	})
 
 	p := NewProcessor(Config{
-		MaxEventSize:   100 * 1024,
-		MaxConcurrency: 1,
+		MaxEventSize: 100 * 1024,
+		Semaphore:    semaphore.NewWeighted(1),
 	})
 	var actualResult Result
 	err := p.HandleStream(context.Background(), false, baseEvent, strings.NewReader(payload), 10, batchProcessor, &actualResult)
@@ -369,21 +370,22 @@ func TestConcurrentAsync(t *testing.T) {
 
 	base := model.APMEvent{Host: model.Host{IP: []netip.Addr{netip.MustParseAddr("192.0.0.1")}}}
 	type testCase struct {
-		payload       string
-		sem, requests int
-		fullSem       bool
+		payload  string
+		sem      int64
+		requests int
+		fullSem  bool
 	}
 
 	test := func(tc testCase) (pResult Result) {
 		var wg sync.WaitGroup
 		var mu sync.Mutex
 		p := NewProcessor(Config{
-			MaxEventSize:   100 * 1024,
-			MaxConcurrency: int64(tc.sem),
+			MaxEventSize: 100 * 1024,
+			Semaphore:    semaphore.NewWeighted(tc.sem),
 		})
 		if tc.fullSem {
-			for i := 0; i < tc.sem; i++ {
-				p.sem <- struct{}{}
+			for i := int64(0); i < tc.sem; i++ {
+				p.semAcquire(context.Background(), false)
 			}
 		}
 		handleStream := func(ctx context.Context, bp *accountProcessor) {
@@ -418,7 +420,7 @@ func TestConcurrentAsync(t *testing.T) {
 		if !tc.fullSem {
 			// Try to acquire the lock to make sure all the requests have been handled
 			// and the locks have been released.
-			for i := 0; i < tc.sem; i++ {
+			for i := int64(0); i < tc.sem; i++ {
 				p.semAcquire(context.Background(), false)
 			}
 		}

--- a/input/elasticapm/processor_test.go
+++ b/input/elasticapm/processor_test.go
@@ -51,8 +51,8 @@ func TestHandleStreamReaderError(t *testing.T) {
 	}
 
 	sp := NewProcessor(Config{
-		MaxEventSize: 100 * 1024,
-		Semaphore:    make(chan struct{}, 1),
+		MaxEventSize:   100 * 1024,
+		MaxConcurrency: 1,
 	})
 
 	var actualResult Result
@@ -83,8 +83,8 @@ func TestHandleStreamBatchProcessorError(t *testing.T) {
 		err:  ErrQueueFull,
 	}} {
 		sp := NewProcessor(Config{
-			MaxEventSize: 100 * 1024,
-			Semaphore:    make(chan struct{}, 1),
+			MaxEventSize:   100 * 1024,
+			MaxConcurrency: 1,
 		})
 		processor := model.ProcessBatchFunc(func(context.Context, *model.Batch) error {
 			return test.err
@@ -184,8 +184,8 @@ func TestHandleStreamErrors(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var actualResult Result
 			p := NewProcessor(Config{
-				MaxEventSize: len(validMetadata) + 1,
-				Semaphore:    make(chan struct{}, 1),
+				MaxEventSize:   len(validMetadata) + 1,
+				MaxConcurrency: 1,
 			})
 			err := p.HandleStream(
 				context.Background(), false, model.APMEvent{},
@@ -219,8 +219,8 @@ func TestHandleStream(t *testing.T) {
 	}, "\n")
 
 	p := NewProcessor(Config{
-		MaxEventSize: 100 * 1024,
-		Semaphore:    make(chan struct{}, 1),
+		MaxEventSize:   100 * 1024,
+		MaxConcurrency: 1,
 	})
 	err := p.HandleStream(
 		context.Background(), false, model.APMEvent{},
@@ -257,8 +257,8 @@ func TestHandleStreamRUMv3(t *testing.T) {
 	}, "\n")
 
 	p := NewProcessor(Config{
-		MaxEventSize: 100 * 1024,
-		Semaphore:    make(chan struct{}, 1),
+		MaxEventSize:   100 * 1024,
+		MaxConcurrency: 1,
 	})
 	err := p.HandleStream(
 		context.Background(), false, model.APMEvent{},
@@ -305,8 +305,8 @@ func TestHandleStreamBaseEvent(t *testing.T) {
 
 	payload := validMetadata + "\n" + validRUMv2Span + "\n"
 	p := NewProcessor(Config{
-		MaxEventSize: 100 * 1024,
-		Semaphore:    make(chan struct{}, 1),
+		MaxEventSize:   100 * 1024,
+		MaxConcurrency: 1,
 	})
 	err := p.HandleStream(
 		context.Background(), false, baseEvent,
@@ -338,8 +338,8 @@ func TestLabelLeak(t *testing.T) {
 	})
 
 	p := NewProcessor(Config{
-		MaxEventSize: 100 * 1024,
-		Semaphore:    make(chan struct{}, 1),
+		MaxEventSize:   100 * 1024,
+		MaxConcurrency: 1,
 	})
 	var actualResult Result
 	err := p.HandleStream(context.Background(), false, baseEvent, strings.NewReader(payload), 10, batchProcessor, &actualResult)
@@ -378,8 +378,8 @@ func TestConcurrentAsync(t *testing.T) {
 		var wg sync.WaitGroup
 		var mu sync.Mutex
 		p := NewProcessor(Config{
-			MaxEventSize: 100 * 1024,
-			Semaphore:    make(chan struct{}, tc.sem),
+			MaxEventSize:   100 * 1024,
+			MaxConcurrency: int64(tc.sem),
 		})
 		if tc.fullSem {
 			for i := 0; i < tc.sem; i++ {

--- a/input/semaphore.go
+++ b/input/semaphore.go
@@ -21,7 +21,14 @@ import "context"
 
 // Semaphore is used by inputs to limit the number of concurrent requests
 type Semaphore interface {
+	// Acquire acquires the semaphore with a weight of n, blocking until
+	// resources are available or ctx is done. On success, returns nil. On
+	// failure, returns ctx.Err() and leaves the semaphore unchanged.
 	Acquire(context.Context, int64) error
+	// TryAcquire acquires the semaphore with a weight of n without blocking. On
+	// success, returns true. On failure, returns false and leaves the semaphore
+	// unchanged.
 	TryAcquire(int64) bool
+	// Release releases the semaphore with a weight of n.
 	Release(int64)
 }

--- a/input/semaphore.go
+++ b/input/semaphore.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package input
+
+import "context"
+
+// Semaphore is used by inputs to limit the number of concurrent requests
+type Semaphore interface {
+	Acquire(context.Context, int64) error
+	TryAcquire(int64) bool
+	Release(int64)
+}


### PR DESCRIPTION
Exposing the `Semaphore` config is exposing an implementation detail. Services using this library only care about the effect of the semaphore (the maximum number of concurrencies), not that it's using a channel.

Also, by exposing a channel, we can't change the underlying implementation, and (for example) switch to [golang.org/x/sync/semaphore](https://pkg.go.dev/golang.org/x/sync/semaphore).