### PR TITLE
Setup otlp max concurrency semaphore

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -48,6 +48,11 @@ import (
 )
 
 func (c *Consumer) ConsumeLogs(ctx context.Context, logs plog.Logs) error {
+	if err := c.sem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer c.sem.Release(1)
+
 	receiveTimestamp := time.Now()
 	c.config.Logger.Debug("consuming logs", zap.Stringer("logs", logsStringer(logs)))
 	resourceLogs := logs.ResourceLogs()

--- a/input/otlp/logs_test.go
+++ b/input/otlp/logs_test.go
@@ -46,6 +46,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/elastic/apm-data/input/otlp"
 	"github.com/elastic/apm-data/model"
@@ -59,8 +60,8 @@ func TestConsumerConsumeLogs(t *testing.T) {
 		}
 
 		consumer := otlp.NewConsumer(otlp.ConsumerConfig{
-			Processor:      processor,
-			MaxConcurrency: 100,
+			Processor: processor,
+			Semaphore: semaphore.NewWeighted(100),
 		})
 		logs := plog.NewLogs()
 		assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
@@ -105,8 +106,8 @@ func TestConsumerConsumeLogs(t *testing.T) {
 				return nil
 			}
 			consumer := otlp.NewConsumer(otlp.ConsumerConfig{
-				Processor:      processor,
-				MaxConcurrency: 100,
+				Processor: processor,
+				Semaphore: semaphore.NewWeighted(100),
 			})
 			assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
@@ -133,8 +134,8 @@ func TestConsumeLogsSemaphore(t *testing.T) {
 		return nil
 	})
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
-		Processor:      recorder,
-		MaxConcurrency: 1,
+		Processor: recorder,
+		Semaphore: semaphore.NewWeighted(1),
 	})
 
 	startCh := make(chan struct{})
@@ -199,8 +200,8 @@ Caused by: LowLevelException
 		return nil
 	}
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
-		Processor:      processor,
-		MaxConcurrency: 100,
+		Processor: processor,
+		Semaphore: semaphore.NewWeighted(100),
 	})
 	assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
@@ -340,8 +341,8 @@ func TestConsumerConsumeOTelEventLogs(t *testing.T) {
 		return nil
 	}
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
-		Processor:      processor,
-		MaxConcurrency: 100,
+		Processor: processor,
+		Semaphore: semaphore.NewWeighted(100),
 	})
 	assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
@@ -383,8 +384,8 @@ func TestConsumerConsumeLogsLabels(t *testing.T) {
 		return nil
 	}
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
-		Processor:      processor,
-		MaxConcurrency: 100,
+		Processor: processor,
+		Semaphore: semaphore.NewWeighted(100),
 	})
 	assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 

--- a/input/otlp/logs_test.go
+++ b/input/otlp/logs_test.go
@@ -58,7 +58,10 @@ func TestConsumerConsumeLogs(t *testing.T) {
 			return nil
 		}
 
-		consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: processor})
+		consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+			Processor:      processor,
+			MaxConcurrency: 100,
+		})
 		logs := plog.NewLogs()
 		assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 	})
@@ -101,7 +104,10 @@ func TestConsumerConsumeLogs(t *testing.T) {
 				processed[0].Timestamp = time.Time{}
 				return nil
 			}
-			consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: processor})
+			consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+				Processor:      processor,
+				MaxConcurrency: 100,
+			})
 			assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
 			expected := commonEvent
@@ -192,7 +198,10 @@ Caused by: LowLevelException
 		processed[0].Timestamp = time.Time{}
 		return nil
 	}
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: processor})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      processor,
+		MaxConcurrency: 100,
+	})
 	assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
 	assert.Len(t, processed, 2)
@@ -330,7 +339,10 @@ func TestConsumerConsumeOTelEventLogs(t *testing.T) {
 		processed[0].Timestamp = time.Time{}
 		return nil
 	}
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: processor})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      processor,
+		MaxConcurrency: 100,
+	})
 	assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
 	assert.Len(t, processed, 1)
@@ -370,7 +382,10 @@ func TestConsumerConsumeLogsLabels(t *testing.T) {
 		processed[0].Timestamp = time.Time{}
 		return nil
 	}
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: processor})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      processor,
+		MaxConcurrency: 100,
+	})
 	assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
 	assert.Len(t, processed, 3)

--- a/input/otlp/metrics.go
+++ b/input/otlp/metrics.go
@@ -51,6 +51,11 @@ import (
 // ConsumeMetrics consumes OpenTelemetry metrics data, converting into
 // the Elastic APM metrics model and sending to the reporter.
 func (c *Consumer) ConsumeMetrics(ctx context.Context, metrics pmetric.Metrics) error {
+	if err := c.sem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer c.sem.Release(1)
+
 	receiveTimestamp := time.Now()
 	c.config.Logger.Debug("consuming metrics", zap.Stringer("metrics", metricsStringer(metrics)))
 	batch := c.convertMetrics(metrics, receiveTimestamp)

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/elastic/apm-data/input/otlp"
 	"github.com/elastic/apm-data/model"
@@ -228,8 +229,8 @@ func TestConsumeMetricsSemaphore(t *testing.T) {
 		return nil
 	})
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
-		Processor:      recorder,
-		MaxConcurrency: 1,
+		Processor: recorder,
+		Semaphore: semaphore.NewWeighted(1),
 	})
 
 	startCh := make(chan struct{})
@@ -743,8 +744,8 @@ func transformMetrics(t *testing.T, metrics pmetric.Metrics) ([]model.APMEvent, 
 	recorder := batchRecorderBatchProcessor(&batches)
 
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
-		Processor:      recorder,
-		MaxConcurrency: 100,
+		Processor: recorder,
+		Semaphore: semaphore.NewWeighted(100),
 	})
 	err := consumer.ConsumeMetrics(context.Background(), metrics)
 	require.NoError(t, err)

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -742,7 +742,10 @@ func transformMetrics(t *testing.T, metrics pmetric.Metrics) ([]model.APMEvent, 
 	var batches []*model.Batch
 	recorder := batchRecorderBatchProcessor(&batches)
 
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: recorder})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      recorder,
+		MaxConcurrency: 100,
+	})
 	err := consumer.ConsumeMetrics(context.Background(), metrics)
 	require.NoError(t, err)
 	require.Len(t, batches, 1)

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -75,6 +75,11 @@ const (
 // ConsumeTraces consumes OpenTelemetry trace data,
 // converting into Elastic APM events and reporting to the Elastic APM schema.
 func (c *Consumer) ConsumeTraces(ctx context.Context, traces ptrace.Traces) error {
+	if err := c.sem.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer c.sem.Release(1)
+
 	receiveTimestamp := time.Now()
 	c.config.Logger.Debug("consuming traces", zap.Stringer("traces", tracesStringer(traces)))
 

--- a/input/otlp/traces_test.go
+++ b/input/otlp/traces_test.go
@@ -66,7 +66,10 @@ func TestConsumer_ConsumeTraces_Empty(t *testing.T) {
 		return nil
 	}
 
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: processor})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      processor,
+		MaxConcurrency: 100,
+	})
 	traces := ptrace.NewTraces()
 	assert.NoError(t, consumer.ConsumeTraces(context.Background(), traces))
 }
@@ -870,7 +873,10 @@ func TestConsumer_JaegerMetadata(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var batches []*model.Batch
 			recorder := batchRecorderBatchProcessor(&batches)
-			consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: recorder})
+			consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+				Processor:      recorder,
+				MaxConcurrency: 100,
+			})
 
 			jaegerBatch.Process = tc.process
 			traces, err := jaegertranslator.ProtoToTraces([]*jaegermodel.Batch{jaegerBatch})
@@ -925,7 +931,10 @@ func TestConsumer_JaegerSampleRate(t *testing.T) {
 
 	var batches []*model.Batch
 	recorder := batchRecorderBatchProcessor(&batches)
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: recorder})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      recorder,
+		MaxConcurrency: 100,
+	})
 	require.NoError(t, consumer.ConsumeTraces(context.Background(), traces))
 	require.Len(t, batches, 1)
 	batch := *batches[0]
@@ -944,7 +953,10 @@ func TestConsumer_JaegerSampleRate(t *testing.T) {
 func TestConsumer_JaegerTraceID(t *testing.T) {
 	var batches []*model.Batch
 	recorder := batchRecorderBatchProcessor(&batches)
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: recorder})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      recorder,
+		MaxConcurrency: 100,
+	})
 
 	traces, err := jaegertranslator.ProtoToTraces([]*jaegermodel.Batch{{
 		Process: jaegermodel.NewProcess("", jaegerKeyValues("jaeger.version", "unknown")),
@@ -1081,7 +1093,10 @@ func TestConsumer_JaegerTransaction(t *testing.T) {
 
 			var batches []*model.Batch
 			recorder := batchRecorderBatchProcessor(&batches)
-			consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: recorder})
+			consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+				Processor:      recorder,
+				MaxConcurrency: 100,
+			})
 			require.NoError(t, consumer.ConsumeTraces(context.Background(), traces))
 
 			docs := encodeBatch(t, batches...)
@@ -1198,7 +1213,10 @@ func TestConsumer_JaegerSpan(t *testing.T) {
 
 			var batches []*model.Batch
 			recorder := batchRecorderBatchProcessor(&batches)
-			consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: recorder})
+			consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+				Processor:      recorder,
+				MaxConcurrency: 100,
+			})
 			require.NoError(t, consumer.ConsumeTraces(context.Background(), traces))
 
 			docs := encodeBatch(t, batches...)
@@ -1228,7 +1246,10 @@ func TestJaegerServiceVersion(t *testing.T) {
 
 	var batches []*model.Batch
 	recorder := batchRecorderBatchProcessor(&batches)
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: recorder})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      recorder,
+		MaxConcurrency: 100,
+	})
 	require.NoError(t, consumer.ConsumeTraces(context.Background(), traces))
 
 	batch := *batches[0]
@@ -1619,7 +1640,10 @@ func transformTraces(t *testing.T, traces ptrace.Traces) model.Batch {
 		processed = *batch
 		return nil
 	})
-	consumer := otlp.NewConsumer(otlp.ConsumerConfig{Processor: processor})
+	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
+		Processor:      processor,
+		MaxConcurrency: 100,
+	})
 	require.NoError(t, consumer.ConsumeTraces(context.Background(), traces))
 	return processed
 }


### PR DESCRIPTION
This adds a `MaxConcurrency` config for the OTLP consumer, and sets up a semaphore to limit the maximum number of concurrent exports.

See https://github.com/elastic/apm-server/issues/9242
Related: https://github.com/elastic/apm-data/pull/55