### PR TITLE
feat: add protobuf utils and improve compatibility for easier migration

### DIFF
--- a/model/apmevent.go
+++ b/model/apmevent.go
@@ -91,11 +91,11 @@ func (e *APMEvent) MarshalJSON() ([]byte, error) {
 // MarshalFastJSON marshals e as JSON, writing the result to w.
 func (e *APMEvent) MarshalFastJSON(w *fastjson.Writer) error {
 	var outProto modelpb.APMEvent
-	e.toModelProtobuf(&outProto)
+	e.ToModelProtobuf(&outProto)
 	return outProto.MarshalFastJSON(w)
 }
 
-func (e *APMEvent) toModelProtobuf(out *modelpb.APMEvent) {
+func (e *APMEvent) ToModelProtobuf(out *modelpb.APMEvent) {
 	var labels map[string]*modelpb.LabelValue
 	if n := len(e.Labels); n > 0 {
 		labels = make(map[string]*modelpb.LabelValue, n)

--- a/model/apmevent.go
+++ b/model/apmevent.go
@@ -95,6 +95,7 @@ func (e *APMEvent) MarshalFastJSON(w *fastjson.Writer) error {
 	return outProto.MarshalFastJSON(w)
 }
 
+// ToModelProtobuf converts e to a protobuf model
 func (e *APMEvent) ToModelProtobuf(out *modelpb.APMEvent) {
 	var labels map[string]*modelpb.LabelValue
 	if n := len(e.Labels); n > 0 {

--- a/model/modelpb/batch.go
+++ b/model/modelpb/batch.go
@@ -15,13 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package model
+package modelpb
 
-import (
-	"context"
-
-	"github.com/elastic/apm-data/model/modelpb"
-)
+import "context"
 
 // BatchProcessor can be used to process a batch of events, giving the
 // opportunity to update, add or remove events.
@@ -47,21 +43,4 @@ func (f ProcessBatchFunc) ProcessBatch(ctx context.Context, b *Batch) error {
 }
 
 // Batch is a collection of APM events.
-type Batch []APMEvent
-
-// ProtoBatchProcessor is a compatibility layer to make it easier to migrate to modelpb.BatchProcessor
-func ProtoBatchProcessor(p modelpb.BatchProcessor) BatchProcessor {
-	return ProcessBatchFunc(func(ctx context.Context, b *Batch) error {
-		batch := make(modelpb.Batch, 0, len(*b))
-		for _, v := range *b {
-			batch = append(batch, toPb(&v))
-		}
-		return p.ProcessBatch(ctx, &batch)
-	})
-}
-
-func toPb(e *APMEvent) *modelpb.APMEvent {
-	var out modelpb.APMEvent
-	e.ToModelProtobuf(&out)
-	return &out
-}
+type Batch []*APMEvent

--- a/model/modelpb/labels.go
+++ b/model/modelpb/labels.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelpb
+
+// Labels wraps a map[string]string or map[string][]string with utility
+// methods.
+type Labels map[string]*LabelValue
+
+// Set sets the label k to value v. If there existed a label in l with the same
+// key, it will be replaced and its Global field will be set to false.
+func (l Labels) Set(k string, v string) {
+	l[k] = &LabelValue{Value: v}
+}
+
+// SetSlice sets the label k to value v. If there existed a label in l with the
+// same key, it will be replaced and its Global field will be set to false.
+func (l Labels) SetSlice(k string, v []string) {
+	l[k] = &LabelValue{Values: v}
+}
+
+// Clone creates a deep copy of Labels.
+func (l Labels) Clone() Labels {
+	cp := make(Labels)
+	for k, v := range l {
+		to := LabelValue{Global: v.Global, Value: v.Value}
+		if len(v.Values) > 0 {
+			to.Values = make([]string, len(v.Values))
+			copy(to.Values, v.Values)
+		}
+		cp[k] = &to
+	}
+	return cp
+}
+
+// NumericLabels wraps a map[string]float64 or map[string][]float64 with utility
+// methods.
+type NumericLabels map[string]*NumericLabelValue
+
+// Set sets the label k to value v. If there existed a label in l with the same
+// key, it will be replaced and its Global field will be set to false.
+func (l NumericLabels) Set(k string, v float64) {
+	l[k] = &NumericLabelValue{Value: v}
+}
+
+// SetSlice sets the label k to value v. If there existed a label in l with the
+// same key, it will be replaced and its Global field will be set to false.
+func (l NumericLabels) SetSlice(k string, v []float64) {
+	l[k] = &NumericLabelValue{Values: v}
+}
+
+// Clone creates a deep copy of NumericLabels.
+func (l NumericLabels) Clone() NumericLabels {
+	cp := make(NumericLabels)
+	for k, v := range l {
+		to := NumericLabelValue{Global: v.Global, Value: v.Value}
+		if len(v.Values) > 0 {
+			to.Values = make([]float64, len(v.Values))
+			copy(to.Values, v.Values)
+		}
+		cp[k] = &to
+	}
+	return cp
+}

--- a/model/modelpb/processor.go
+++ b/model/modelpb/processor.go
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelpb
+
+const (
+	spanProcessorName         = "transaction"
+	spanProcessorEvent        = "span"
+	transactionProcessorName  = "transaction"
+	transactionProcessorEvent = "transaction"
+	errorProcessorName        = "error"
+	errorProcessorEvent       = "error"
+	logProcessorName          = "log"
+	logProcessorEvent         = "log"
+	metricsetProcessorName    = "metric"
+	metricsetProcessorEvent   = "metric"
+)
+
+func SpanProcessor() *Processor {
+	return &Processor{
+		Name:  spanProcessorName,
+		Event: spanProcessorEvent,
+	}
+}
+
+func (p *Processor) IsSpan() bool {
+	return p.Name == spanProcessorName && p.Event == spanProcessorEvent
+}
+
+func TransactionProcessor() *Processor {
+	return &Processor{
+		Name:  transactionProcessorName,
+		Event: transactionProcessorEvent,
+	}
+}
+
+func (p *Processor) IsTransaction() bool {
+	return p.Name == transactionProcessorName && p.Event == transactionProcessorEvent
+}
+
+func ErrorProcessor() *Processor {
+	return &Processor{
+		Name:  errorProcessorName,
+		Event: errorProcessorEvent,
+	}
+}
+
+func (p *Processor) IsError() bool {
+	return p.Name == errorProcessorName && p.Event == errorProcessorEvent
+}
+
+func LogProcessor() *Processor {
+	return &Processor{
+		Name:  logProcessorName,
+		Event: logProcessorEvent,
+	}
+}
+
+func (p *Processor) IsLog() bool {
+	return p.Name == logProcessorName && p.Event == logProcessorEvent
+}
+
+func MetricsetProcessor() *Processor {
+	return &Processor{
+		Name:  metricsetProcessorName,
+		Event: metricsetProcessorEvent,
+	}
+}
+
+func (p *Processor) IsMetricset() bool {
+	return p.Name == metricsetProcessorName && p.Event == metricsetProcessorEvent
+}

--- a/model/modelpb/url.go
+++ b/model/modelpb/url.go
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelpb
+
+import (
+	"net/url"
+	"strconv"
+)
+
+func ParseURL(original, defaultHostname, defaultScheme string) *URL {
+	original = truncate(original)
+	url, err := url.Parse(original)
+	if err != nil {
+		return &URL{Original: original}
+	}
+	if url.Scheme == "" {
+		url.Scheme = defaultScheme
+		if url.Scheme == "" {
+			url.Scheme = "http"
+		}
+	}
+	if url.Host == "" {
+		url.Host = defaultHostname
+	}
+	out := URL{
+		Original: original,
+		Scheme:   url.Scheme,
+		Full:     truncate(url.String()),
+		Domain:   truncate(url.Hostname()),
+		Path:     truncate(url.Path),
+		Query:    truncate(url.RawQuery),
+		Fragment: url.Fragment,
+	}
+	if port := url.Port(); port != "" {
+		if intv, err := strconv.Atoi(port); err == nil {
+			out.Port = uint32(intv)
+		}
+	}
+	return &out
+}
+
+// truncate returns s truncated at n runes, and the number of runes in the resulting string (<= n).
+func truncate(s string) string {
+	var j int
+	for i := range s {
+		if j == 1024 {
+			return s[:i]
+		}
+		j++
+	}
+	return s
+}


### PR DESCRIPTION
This PR is adding a few methods for easier migration to protobuf in APM Server:

- `ToModelProtobuf` is made public to allow converting from classic/old `model` to protobuf `modelpb`
- Add a `ProtoBatchProcessor` as a compatibility layer between `model.BatchProcessor` and `modelpb.BatchProcessor`
- Add `modelpb.BatchProcessor`: required for migrating to protobuf
- `modelpb` labels: these are type aliases with utility methods, similar to what we have for the classic/old `model`s
- url utility methods similar to what we had for the classic/old `model`s