### PR TITLE
fix: use getter to avoid nil pointer dereference in processor utils

### DIFF
--- a/model/modelpb/apmevent.pb.json.go
+++ b/model/modelpb/apmevent.pb.json.go
@@ -112,14 +112,11 @@ func (e *APMEvent) MarshalFastJSON(w *fastjson.Writer) error {
 	//
 	// TODO(axw) change @timestamp to use date_nanos, and remove this field.
 	var timestampStruct modeljson.Timestamp
-	if !e.Timestamp.AsTime().IsZero() {
-		if e.Processor != nil {
-			processorName := e.Processor.Name
-			processorEvent := e.Processor.Event
-			if (processorName == "error" && processorEvent == "error") || (processorName == "transaction" && (processorEvent == "transaction" || processorEvent == "span")) {
-				timestampStruct.US = int(e.Timestamp.AsTime().UnixNano() / 1000)
-				doc.TimestampStruct = &timestampStruct
-			}
+	if e.Timestamp != nil && !e.Timestamp.AsTime().IsZero() {
+		switch {
+		case e.Processor.IsTransaction(), e.Processor.IsSpan(), e.Processor.IsError():
+			timestampStruct.US = int(e.Timestamp.AsTime().UnixNano() / 1000)
+			doc.TimestampStruct = &timestampStruct
 		}
 	}
 

--- a/model/modelpb/processor.go
+++ b/model/modelpb/processor.go
@@ -38,7 +38,7 @@ func SpanProcessor() *Processor {
 }
 
 func (p *Processor) IsSpan() bool {
-	return p.Name == spanProcessorName && p.Event == spanProcessorEvent
+	return p.GetName() == spanProcessorName && p.GetEvent() == spanProcessorEvent
 }
 
 func TransactionProcessor() *Processor {
@@ -49,7 +49,7 @@ func TransactionProcessor() *Processor {
 }
 
 func (p *Processor) IsTransaction() bool {
-	return p.Name == transactionProcessorName && p.Event == transactionProcessorEvent
+	return p.GetName() == transactionProcessorName && p.GetEvent() == transactionProcessorEvent
 }
 
 func ErrorProcessor() *Processor {
@@ -60,7 +60,7 @@ func ErrorProcessor() *Processor {
 }
 
 func (p *Processor) IsError() bool {
-	return p.Name == errorProcessorName && p.Event == errorProcessorEvent
+	return p.GetName() == errorProcessorName && p.GetEvent() == errorProcessorEvent
 }
 
 func LogProcessor() *Processor {
@@ -71,7 +71,7 @@ func LogProcessor() *Processor {
 }
 
 func (p *Processor) IsLog() bool {
-	return p.Name == logProcessorName && p.Event == logProcessorEvent
+	return p.GetName() == logProcessorName && p.GetEvent() == logProcessorEvent
 }
 
 func MetricsetProcessor() *Processor {
@@ -82,5 +82,5 @@ func MetricsetProcessor() *Processor {
 }
 
 func (p *Processor) IsMetricset() bool {
-	return p.Name == metricsetProcessorName && p.Event == metricsetProcessorEvent
+	return p.GetName() == metricsetProcessorName && p.GetEvent() == metricsetProcessorEvent
 }


### PR DESCRIPTION
Small fix for a nil pointer dereference.

Processor utils supports nil receiver and they should be more resilient in general

Related to https://github.com/elastic/apm-data/issues/52