### PR TITLE
fix: only map selftime.sum to protobuf if the sum is not zero

### DIFF
--- a/model/span.go
+++ b/model/span.go
@@ -119,7 +119,9 @@ func (e *Span) toModelProtobuf(out *modelpb.Span) {
 	if !isZero(e.SelfTime) {
 		out.SelfTime = &modelpb.AggregatedDuration{
 			Count: int64(e.SelfTime.Count),
-			Sum:   durationpb.New(e.SelfTime.Sum),
+		}
+		if e.SelfTime.Sum != 0 {
+			out.SelfTime.Sum = durationpb.New(e.SelfTime.Sum)
 		}
 	}
 	if e.DB != nil {


### PR DESCRIPTION
Small fix for protobuf mapping.

sum is a pointer type, we should only set one if the value is not empty to have the same behaviour as the old/classic models

Related to https://github.com/elastic/apm-data/issues/52