### PR TITLE
feat: normalize interface before converting to structpb

### DIFF
--- a/input/elasticapm/internal/modeldecoder/v2/decoder.go
+++ b/input/elasticapm/internal/modeldecoder/v2/decoder.go
@@ -434,9 +434,7 @@ func mapToErrorModel(from *errorEvent, event *modelpb.APMEvent) {
 			}
 		}
 		if len(from.Context.Custom) > 0 {
-			if m := modeldecoderutil.NormalizeMap(from.Context.Custom); len(m) > 0 {
-				out.Custom = modeldecoderutil.ToStruct(m)
-			}
+			out.Custom = modeldecoderutil.ToStruct(from.Context.Custom)
 		}
 	}
 	if from.Culprit.IsSet() {
@@ -1292,9 +1290,7 @@ func mapToTransactionModel(from *transaction, event *modelpb.APMEvent) {
 
 	if from.Context.IsSet() {
 		if len(from.Context.Custom) > 0 {
-			if m := modeldecoderutil.NormalizeMap(from.Context.Custom); len(m) > 0 {
-				out.Custom = modeldecoderutil.ToStruct(m)
-			}
+			out.Custom = modeldecoderutil.ToStruct(from.Context.Custom)
 		}
 		if len(from.Context.Tags) > 0 {
 			modeldecoderutil.MergeLabels(from.Context.Tags, event)


### PR DESCRIPTION
structpb conversion could fail if the value is not supported. To avoid an error and losing data we normalize the value to make sure we are dealing with supported types.