### PR TITLE
Set `Event.Received` for traces base event

### DIFF
--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -99,7 +99,11 @@ func (c *Consumer) convertResourceSpans(
 	receiveTimestamp time.Time,
 	out *modelpb.Batch,
 ) {
-	var baseEvent modelpb.APMEvent
+	baseEvent := modelpb.APMEvent{
+		Event: &modelpb.Event{
+			Received: timestamppb.New(receiveTimestamp),
+		},
+	}
 	var timeDelta time.Duration
 	resource := resourceSpans.Resource()
 	translateResourceMetadata(resource, &baseEvent)

--- a/input/otlp/traces_test.go
+++ b/input/otlp/traces_test.go
@@ -824,6 +824,21 @@ func TestConsumeTracesExportTimestamp(t *testing.T) {
 	}
 }
 
+func TestConsumeTracesEventReceived(t *testing.T) {
+	traces, otelSpans := newTracesSpans()
+	now := time.Now()
+
+	otelSpan1 := otelSpans.Spans().AppendEmpty()
+	otelSpan1.SetTraceID(pcommon.TraceID{1})
+	otelSpan1.SetSpanID(pcommon.SpanID{2})
+
+	batch := transformTraces(t, traces)
+	require.Len(t, *batch, 1)
+
+	const allowedDelta = 2 // seconds
+	require.InDelta(t, now.Unix(), (*batch)[0].Event.Received.AsTime().Unix(), allowedDelta)
+}
+
 func TestSpanLinks(t *testing.T) {
 	linkedTraceID := pcommon.TraceID{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	linkedSpanID := pcommon.SpanID{7, 6, 5, 4, 3, 2, 1, 0}


### PR DESCRIPTION
Leveraging the new `Event.Received` field added in #85 this PR adds it to `baseEvent` when consuming OTLP traces.

I added a test case to verify the field presence within a reasonable delta.

Jaeger tests were failing due to the added field. As is a time dependent field based on event processing time I added a custom `Comparer` to the `cmp.Diff` testing Jaeger examples that excludes any field named `received` when comparing. 