### PR TITLE
Set `Event.Received` for logs base event

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -67,7 +67,12 @@ func (c *Consumer) ConsumeLogs(ctx context.Context, logs plog.Logs) error {
 func (c *Consumer) convertResourceLogs(resourceLogs plog.ResourceLogs, receiveTimestamp time.Time, out *modelpb.Batch) {
 	var timeDelta time.Duration
 	resource := resourceLogs.Resource()
-	baseEvent := modelpb.APMEvent{Processor: modelpb.LogProcessor()}
+	baseEvent := modelpb.APMEvent{
+		Event: &modelpb.Event{
+			Received: timestamppb.New(receiveTimestamp),
+		},
+		Processor: modelpb.LogProcessor(),
+	}
 	translateResourceMetadata(resource, &baseEvent)
 
 	if exportTimestamp, ok := exportTimestamp(resource); ok {

--- a/input/otlp/logs_test.go
+++ b/input/otlp/logs_test.go
@@ -112,6 +112,12 @@ func TestConsumerConsumeLogs(t *testing.T) {
 			})
 			assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
+			now := time.Now().Unix()
+			for _, e := range processed {
+				assert.InDelta(t, now, e.Event.Received.AsTime().Unix(), 2)
+				e.Event.Received = nil
+			}
+
 			expected := proto.Clone(&commonEvent).(*modelpb.APMEvent)
 			expected.Message = expectedMessage
 			assert.Empty(t, cmp.Diff(modelpb.Batch{expected}, processed, protocmp.Transform()))
@@ -205,6 +211,12 @@ Caused by: LowLevelException
 		Semaphore: semaphore.NewWeighted(100),
 	})
 	assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
+
+	now := time.Now().Unix()
+	for _, e := range processed {
+		assert.InDelta(t, now, e.Event.Received.AsTime().Unix(), 2)
+		e.Event.Received = nil
+	}
 
 	assert.Len(t, processed, 2)
 	assert.Equal(t, modelpb.Labels{"key0": {Global: true, Value: "zero"}, "key1": {Value: "one"}}, modelpb.Labels(processed[0].Labels))


### PR DESCRIPTION
Leveraging the new `Event.Received` field added in #85 this PR adds it to `baseEvent` when consuming OTLP logs.

I added a test case to verify the field presence within a reasonable delta. The field is then removed to prevent test failures related to exact time comparisons.

