### PR TITLE
Set `Event.Received` for metrics base event

### DIFF
--- a/input/otlp/metrics.go
+++ b/input/otlp/metrics.go
@@ -73,7 +73,12 @@ func (c *Consumer) convertMetrics(metrics pmetric.Metrics, receiveTimestamp time
 }
 
 func (c *Consumer) convertResourceMetrics(resourceMetrics pmetric.ResourceMetrics, receiveTimestamp time.Time, out *modelpb.Batch) {
-	var baseEvent modelpb.APMEvent
+	baseEvent := modelpb.APMEvent{
+		Event: &modelpb.Event{
+			Received: timestamppb.New(receiveTimestamp),
+		},
+	}
+
 	var timeDelta time.Duration
 	resource := resourceMetrics.Resource()
 	translateResourceMetadata(resource, &baseEvent)

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -763,6 +763,16 @@ func eventsMatch(t *testing.T, expected []*modelpb.APMEvent, actual []*modelpb.A
 	sort.Slice(actual, func(i, j int) bool {
 		return strings.Compare(actual[i].String(), actual[j].String()) == -1
 	})
+
+	now := time.Now().Unix()
+	for i, e := range actual {
+		assert.InDelta(t, now, e.Event.Received.AsTime().Unix(), 2)
+		e.Event.Received = nil
+		if expected[i].Event == nil {
+			e.Event = nil
+		}
+	}
+
 	diff := cmp.Diff(
 		expected, actual,
 		protocmp.Transform(),


### PR DESCRIPTION
Leveraging the new `Event.Received` field added in #85 this PR adds it to `baseEvent` when consuming OTLP traces.

I added a test case to verify the field presence within a reasonable delta. The field is then removed to prevent test failures related to exact time comparisons.


