### PR TITLE
perf: optimize label sanitization

### DIFF
--- a/model/modelpb/context.go
+++ b/model/modelpb/context.go
@@ -21,7 +21,9 @@ package modelpb
 // suitable for storing as "custom" in transaction and error documents.
 func updateFields(in map[string]any) {
 	for k, v := range in {
-		delete(in, k)
-		in[sanitizeLabelKey(k)] = v
+		if lk := sanitizeLabelKey(k); lk != k {
+			delete(in, k)
+			in[lk] = v
+		}
 	}
 }

--- a/model/modelpb/labels.util.go
+++ b/model/modelpb/labels.util.go
@@ -23,7 +23,10 @@ import "strings"
 // with '_'. Null-valued labels are omitted.
 
 func sanitizeLabelKey(k string) string {
-	return strings.Map(replaceReservedLabelKeyRune, k)
+	if strings.ContainsAny(k, ".*\"") {
+		return strings.Map(replaceReservedLabelKeyRune, k)
+	}
+	return k
 }
 
 func replaceReservedLabelKeyRune(r rune) rune {


### PR DESCRIPTION
The following code was used to microbenchmark the `sanitizeLabel` function:

```
package modelpb

import "testing"

func BenchmarkSanitize(b *testing.B) {
        small := "foobar"
        l := "foobarfoobarfoobarfoobarfoobarfoobarfoobar"
        b.Run("small", func(b *testing.B) {
                for i := 0; i < b.N; i++ {
                        sanitizeLabelKey(small)
                }
        })
        b.Run("l", func(b *testing.B) {
                for i := 0; i < b.N; i++ {
                        sanitizeLabelKey(l)
                }
        })
}
```

Benchmarks show a performance improvement for both small and large label keys:

```
                  │  before.txt  │              after.txt              │
                  │    sec/op    │   sec/op     vs base                │
Sanitize/small-20   16.100n ± 1%   9.191n ± 1%  -42.91% (p=0.000 n=10)
Sanitize/l-20        81.55n ± 1%   29.35n ± 2%  -64.01% (p=0.000 n=10)
geomean              36.23n        16.42n       -54.67%

                  │  before.txt  │              after.txt              │
                  │     B/op     │    B/op     vs base                 │
Sanitize/small-20   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sanitize/l-20       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                        ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                  │  before.txt  │              after.txt              │
                  │  allocs/op   │ allocs/op   vs base                 │
Sanitize/small-20   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Sanitize/l-20       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
```

Closes https://github.com/elastic/apm-data/issues/49