### PR TITLE
fix: update handwritten fastjson methods to avoid fallback to reflection

### DIFF
--- a/model/internal/modeljson/error.go
+++ b/model/internal/modeljson/error.go
@@ -116,9 +116,16 @@ func (e *Exception) marshalOne(w *fastjson.Writer, offset, parentOffset int) (in
 	if len(e.Stacktrace) != 0 {
 		maybeComma()
 		w.RawString(`"stacktrace":`)
-		if err := fastjson.Marshal(w, e.Stacktrace); err != nil {
-			return -1, err
+		w.RawByte('[')
+		for i, v := range e.Stacktrace {
+			if i != 0 {
+				w.RawByte(',')
+			}
+			if err := v.MarshalFastJSON(w); err != nil {
+				return -1, err
+			}
 		}
+		w.RawByte(']')
 	}
 	w.RawByte('}')
 

--- a/model/internal/modeljson/error.go
+++ b/model/internal/modeljson/error.go
@@ -121,7 +121,7 @@ func (e *Exception) marshalOne(w *fastjson.Writer, offset, parentOffset int) (in
 			if i != 0 {
 				w.RawByte(',')
 			}
-			if err := v.MarshalFastJSON(w); err != nil {
+			if err := fastjson.Marshal(w, &v); err != nil {
 				return -1, err
 			}
 		}

--- a/model/internal/modeljson/experience.go
+++ b/model/internal/modeljson/experience.go
@@ -61,7 +61,7 @@ func (u *UserExperience) MarshalFastJSON(w *fastjson.Writer) error {
 			w.RawByte(',')
 		}
 		w.RawString(`"longtask":`)
-		if err := fastjson.Marshal(w, u.Longtask); err != nil {
+		if err := u.Longtask.MarshalFastJSON(w); err != nil {
 			return err
 		}
 	}

--- a/model/internal/modeljson/experience.go
+++ b/model/internal/modeljson/experience.go
@@ -61,7 +61,7 @@ func (u *UserExperience) MarshalFastJSON(w *fastjson.Writer) error {
 			w.RawByte(',')
 		}
 		w.RawString(`"longtask":`)
-		if err := u.Longtask.MarshalFastJSON(w); err != nil {
+		if err := fastjson.Marshal(w, &u.Longtask); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Some handwritten fastjson methods were calling fastjson.Marshal with the wrong types, leading to the library falling back to the slow reflection-based marshaling logic.