### PR TITLE
otlp: fix panic on unknown sampler.type for spans

### DIFF
--- a/input/otlp/test_approved/jaeger_sampling_rate.approved.json
+++ b/input/otlp/test_approved/jaeger_sampling_rate.approved.json
@@ -105,6 +105,48 @@
                 "sampled": true,
                 "type": "unknown"
             }
+        },
+        {
+            "@timestamp": "2019-12-16T12:46:58.000Z",
+            "agent": {
+                "name": "Jaeger",
+                "version": "unknown"
+            },
+            "event": {
+                "duration": 79000000000,
+                "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host-abc"
+            },
+            "labels": {
+                "sampler_type": "const"
+            },
+            "numeric_labels": {
+                "sampler_param": 1
+            },
+            "parent": {
+                "id": "0000000000000001"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "language": {
+                    "name": "unknown"
+                },
+                "name": "unknown"
+            },
+            "span": {
+                "type": "unknown"
+            },
+            "timestamp": {
+                "us": 1576500418000768
+            },
+            "trace": {
+                "id": "00000000000000010000000000000001"
+            }
         }
     ]
 }

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -858,7 +858,12 @@ func parseSamplerAttributes(samplerType, samplerParam pcommon.Value, event *mode
 			}
 		}
 	default:
-		event.Transaction.RepresentativeCount = 0
+		if event.Span != nil {
+			event.Span.RepresentativeCount = 0
+		}
+		if event.Transaction != nil {
+			event.Transaction.RepresentativeCount = 0
+		}
 		modelpb.Labels(event.Labels).Set("sampler_type", samplerType)
 		switch samplerParam.Type() {
 		case pcommon.ValueTypeBool:

--- a/input/otlp/traces_test.go
+++ b/input/otlp/traces_test.go
@@ -981,6 +981,20 @@ func TestConsumer_JaegerSampleRate(t *testing.T) {
 				jaegerKeyValue("sampler.type", "ratelimiting"),
 				jaegerKeyValue("sampler.param", 2.0), // 2 traces per second
 			},
+		}, {
+			StartTime: testStartTime(),
+			Duration:  testDuration(),
+			TraceID:   jaegermodel.NewTraceID(1, 1),
+			References: []jaegermodel.SpanRef{{
+				RefType: jaegermodel.SpanRefType_CHILD_OF,
+				TraceID: jaegermodel.NewTraceID(1, 1),
+				SpanID:  1,
+			}},
+			Tags: []jaegermodel.KeyValue{
+				jaegerKeyValue("span.kind", "client"),
+				jaegerKeyValue("sampler.type", "const"),
+				jaegerKeyValue("sampler.param", 1.0),
+			},
 		}},
 	}})
 	require.NoError(t, err)


### PR DESCRIPTION
Handling of Jaeger's `sampler.type` attribute would panic when when it's not "probabilistic", and when translating a span.