### PR TITLE
Return the context in ProcessBatch

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -61,7 +61,8 @@ func (c *Consumer) ConsumeLogs(ctx context.Context, logs plog.Logs) error {
 	for i := 0; i < resourceLogs.Len(); i++ {
 		c.convertResourceLogs(resourceLogs.At(i), receiveTimestamp, &batch)
 	}
-	return c.config.Processor.ProcessBatch(ctx, &batch)
+	_, err := c.config.Processor.ProcessBatch(ctx, &batch)
+	return err
 }
 
 func (c *Consumer) convertResourceLogs(resourceLogs plog.ResourceLogs, receiveTimestamp time.Time, out *modelpb.Batch) {

--- a/input/otlp/logs_test.go
+++ b/input/otlp/logs_test.go
@@ -55,9 +55,9 @@ import (
 
 func TestConsumerConsumeLogs(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		var processor modelpb.ProcessBatchFunc = func(_ context.Context, batch *modelpb.Batch) error {
+		var processor modelpb.ProcessBatchFunc = func(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
 			assert.Empty(t, batch)
-			return nil
+			return ctx, nil
 		}
 
 		consumer := otlp.NewConsumer(otlp.ConsumerConfig{
@@ -97,14 +97,14 @@ func TestConsumerConsumeLogs(t *testing.T) {
 			newLogRecord(body).CopyTo(scopeLogs.LogRecords().AppendEmpty())
 
 			var processed modelpb.Batch
-			var processor modelpb.ProcessBatchFunc = func(_ context.Context, batch *modelpb.Batch) error {
+			var processor modelpb.ProcessBatchFunc = func(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
 				if processed != nil {
 					panic("already processes batch")
 				}
 				processed = *batch
 				assert.NotNil(t, processed[0].Timestamp)
 				processed[0].Timestamp = nil
-				return nil
+				return ctx, nil
 			}
 			consumer := otlp.NewConsumer(otlp.ConsumerConfig{
 				Processor: processor,
@@ -135,10 +135,10 @@ func TestConsumeLogsSemaphore(t *testing.T) {
 	var batches []*modelpb.Batch
 
 	doneCh := make(chan struct{})
-	recorder := modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) error {
+	recorder := modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
 		<-doneCh
 		batches = append(batches, batch)
-		return nil
+		return ctx, nil
 	})
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
 		Processor: recorder,
@@ -197,14 +197,14 @@ Caused by: LowLevelException
 	record2.CopyTo(scopeLogs.LogRecords().AppendEmpty())
 
 	var processed modelpb.Batch
-	var processor modelpb.ProcessBatchFunc = func(_ context.Context, batch *modelpb.Batch) error {
+	var processor modelpb.ProcessBatchFunc = func(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
 		if processed != nil {
 			panic("already processes batch")
 		}
 		processed = *batch
 		assert.NotNil(t, processed[0].Timestamp)
 		processed[0].Timestamp = nil
-		return nil
+		return ctx, nil
 	}
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
 		Processor: processor,
@@ -348,14 +348,14 @@ func TestConsumerConsumeOTelEventLogs(t *testing.T) {
 	record1.CopyTo(scopeLogs.LogRecords().AppendEmpty())
 
 	var processed modelpb.Batch
-	var processor modelpb.ProcessBatchFunc = func(_ context.Context, batch *modelpb.Batch) error {
+	var processor modelpb.ProcessBatchFunc = func(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
 		if processed != nil {
 			panic("already processes batch")
 		}
 		processed = *batch
 		assert.NotNil(t, processed[0].Timestamp)
 		processed[0].Timestamp = timestamppb.New(time.Time{})
-		return nil
+		return ctx, nil
 	}
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
 		Processor: processor,
@@ -391,14 +391,14 @@ func TestConsumerConsumeLogsLabels(t *testing.T) {
 	record3.CopyTo(scopeLogs.LogRecords().AppendEmpty())
 
 	var processed modelpb.Batch
-	var processor modelpb.ProcessBatchFunc = func(_ context.Context, batch *modelpb.Batch) error {
+	var processor modelpb.ProcessBatchFunc = func(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
 		if processed != nil {
 			panic("already processes batch")
 		}
 		processed = *batch
 		assert.NotNil(t, processed[0].Timestamp)
 		processed[0].Timestamp = timestamppb.New(time.Time{})
-		return nil
+		return ctx, nil
 	}
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
 		Processor: processor,

--- a/input/otlp/metrics.go
+++ b/input/otlp/metrics.go
@@ -60,7 +60,8 @@ func (c *Consumer) ConsumeMetrics(ctx context.Context, metrics pmetric.Metrics) 
 	receiveTimestamp := time.Now()
 	c.config.Logger.Debug("consuming metrics", zap.Stringer("metrics", metricsStringer(metrics)))
 	batch := c.convertMetrics(metrics, receiveTimestamp)
-	return c.config.Processor.ProcessBatch(ctx, batch)
+	_, err := c.config.Processor.ProcessBatch(ctx, batch)
+	return err
 }
 
 func (c *Consumer) convertMetrics(metrics pmetric.Metrics, receiveTimestamp time.Time) *modelpb.Batch {

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -225,10 +225,10 @@ func TestConsumeMetricsSemaphore(t *testing.T) {
 	var batches []*modelpb.Batch
 
 	doneCh := make(chan struct{})
-	recorder := modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) error {
+	recorder := modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
 		<-doneCh
 		batches = append(batches, batch)
-		return nil
+		return ctx, nil
 	})
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{
 		Processor: recorder,

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -91,7 +91,8 @@ func (c *Consumer) ConsumeTraces(ctx context.Context, traces ptrace.Traces) erro
 	for i := 0; i < resourceSpans.Len(); i++ {
 		c.convertResourceSpans(resourceSpans.At(i), receiveTimestamp, &batch)
 	}
-	return c.config.Processor.ProcessBatch(ctx, &batch)
+	_, err := c.config.Processor.ProcessBatch(ctx, &batch)
+	return err
 }
 
 func (c *Consumer) convertResourceSpans(

--- a/model/modelpb/batch.go
+++ b/model/modelpb/batch.go
@@ -31,14 +31,14 @@ type BatchProcessor interface {
 	// method has returned.
 	// If the batch needs to be processed asynchronously or kept around,
 	// the processor must create a copy of the slice.
-	ProcessBatch(context.Context, *Batch) error
+	ProcessBatch(context.Context, *Batch) (context.Context, error)
 }
 
 // ProcessBatchFunc is a function type that implements BatchProcessor.
-type ProcessBatchFunc func(context.Context, *Batch) error
+type ProcessBatchFunc func(context.Context, *Batch) (context.Context, error)
 
 // ProcessBatch calls f(ctx, b)
-func (f ProcessBatchFunc) ProcessBatch(ctx context.Context, b *Batch) error {
+func (f ProcessBatchFunc) ProcessBatch(ctx context.Context, b *Batch) (context.Context, error) {
 	return f(ctx, b)
 }
 

--- a/model/modelprocessor/chained.go
+++ b/model/modelprocessor/chained.go
@@ -28,11 +28,13 @@ import (
 type Chained []modelpb.BatchProcessor
 
 // ProcessBatch calls each of the processors in c in series.
-func (c Chained) ProcessBatch(ctx context.Context, batch *modelpb.Batch) error {
+func (c Chained) ProcessBatch(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
+	var err error
+
 	for _, p := range c {
-		if err := p.ProcessBatch(ctx, batch); err != nil {
-			return err
+		if ctx, err = p.ProcessBatch(ctx, batch); err != nil {
+			return ctx, err
 		}
 	}
-	return nil
+	return ctx, nil
 }

--- a/model/modelprocessor/dropunsampled.go
+++ b/model/modelprocessor/dropunsampled.go
@@ -31,7 +31,7 @@ import (
 //
 // This modelpb.BatchProcessor does not guarantee order preservation of the remaining events.
 func NewDropUnsampled(dropRUM bool, droppedCallback func(int64)) modelpb.BatchProcessor {
-	return modelpb.ProcessBatchFunc(func(_ context.Context, batch *modelpb.Batch) error {
+	return modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) (context.Context, error) {
 		events := *batch
 		for i := 0; i < len(events); {
 			event := events[i]
@@ -47,7 +47,7 @@ func NewDropUnsampled(dropRUM bool, droppedCallback func(int64)) modelpb.BatchPr
 			droppedCallback(int64(dropped))
 		}
 		*batch = events
-		return nil
+		return ctx, nil
 	})
 }
 

--- a/model/modelprocessor/dropunsampled_test.go
+++ b/model/modelprocessor/dropunsampled_test.go
@@ -65,7 +65,7 @@ func TestNewDropUnsampled(t *testing.T) {
 			Transaction: t5,
 		}}
 
-		err := batchProcessor.ProcessBatch(context.Background(), &batch)
+		_, err := batchProcessor.ProcessBatch(context.Background(), &batch)
 		assert.NoError(t, err)
 
 		var expectedTransactionsDropped int64 = 3

--- a/model/modelprocessor/environment.go
+++ b/model/modelprocessor/environment.go
@@ -32,7 +32,7 @@ type SetDefaultServiceEnvironment struct {
 }
 
 // ProcessBatch sets a default service.value for events without one already set.
-func (s *SetDefaultServiceEnvironment) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+func (s *SetDefaultServiceEnvironment) ProcessBatch(ctx context.Context, b *modelpb.Batch) (context.Context, error) {
 	for i := range *b {
 		event := (*b)[i]
 		if event.Service == nil {
@@ -42,5 +42,5 @@ func (s *SetDefaultServiceEnvironment) ProcessBatch(ctx context.Context, b *mode
 			event.Service.Environment = s.DefaultServiceEnvironment
 		}
 	}
-	return nil
+	return ctx, nil
 }

--- a/model/modelprocessor/environment_test.go
+++ b/model/modelprocessor/environment_test.go
@@ -43,7 +43,7 @@ func testProcessBatch(t *testing.T, processor modelpb.BatchProcessor, in, out *m
 	t.Helper()
 
 	batch := &modelpb.Batch{in}
-	err := processor.ProcessBatch(context.Background(), batch)
+	_, err := processor.ProcessBatch(context.Background(), batch)
 	require.NoError(t, err)
 
 	expected := &modelpb.Batch{out}

--- a/model/modelprocessor/hostname.go
+++ b/model/modelprocessor/hostname.go
@@ -29,11 +29,11 @@ import (
 type SetHostHostname struct{}
 
 // ProcessBatch sets or overrides the host.name and host.hostname fields for events.
-func (SetHostHostname) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+func (SetHostHostname) ProcessBatch(ctx context.Context, b *modelpb.Batch) (context.Context, error) {
 	for i := range *b {
 		setHostHostname((*b)[i])
 	}
-	return nil
+	return ctx, nil
 }
 
 func setHostHostname(event *modelpb.APMEvent) {

--- a/model/modelprocessor/nodename.go
+++ b/model/modelprocessor/nodename.go
@@ -31,11 +31,11 @@ import (
 type SetServiceNodeName struct{}
 
 // ProcessBatch sets a default service.node.name for events without one already set.
-func (SetServiceNodeName) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+func (SetServiceNodeName) ProcessBatch(ctx context.Context, b *modelpb.Batch) (context.Context, error) {
 	for i := range *b {
 		setServiceNodeName((*b)[i])
 	}
-	return nil
+	return ctx, nil
 }
 
 func setServiceNodeName(event *modelpb.APMEvent) {


### PR DESCRIPTION
Right now, processors can't communicate with each other, which is something I need to do to start doing tracing within them.
By returning a context after ProcessBatch, the processor can change the context and return a new one, which will be used by every underlying processor.

With that, processors will be able to communicate with each other, and more specifically, one will be able to start a span, and another one to finish it (and possibly every other one, to retrieve the span in context and add attributes).