### PR TITLE
Add tracer modelprocessor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,11 @@ require (
 	go.opentelemetry.io/collector/consumer v0.76.1
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0011
 	go.opentelemetry.io/collector/semconv v0.76.1
+	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/metric v1.16.0
+	go.opentelemetry.io/otel/sdk v1.16.0
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
+	go.opentelemetry.io/otel/trace v1.16.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.2.0
 	golang.org/x/tools v0.9.3
@@ -49,9 +52,6 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	go.opentelemetry.io/otel v1.16.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.16.0 // indirect
-	go.opentelemetry.io/otel/trace v1.16.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/mod v0.10.0 // indirect

--- a/model/modelprocessor/config.go
+++ b/model/modelprocessor/config.go
@@ -30,7 +30,7 @@ type ConfigOption func(config) config
 // The config struct is shared amongst every processor using it, but they may
 // not each use every option.
 type config struct {
-	TracerProvider trace.TracerProvider
+	tracerProvider trace.TracerProvider
 }
 
 func newConfig(opts ...ConfigOption) config {
@@ -39,8 +39,8 @@ func newConfig(opts ...ConfigOption) config {
 		config = opt(config)
 	}
 
-	if config.TracerProvider == nil {
-		config.TracerProvider = otel.GetTracerProvider()
+	if config.tracerProvider == nil {
+		config.tracerProvider = otel.GetTracerProvider()
 	}
 
 	return config
@@ -50,7 +50,7 @@ func newConfig(opts ...ConfigOption) config {
 // Defaults to the global tracer provider
 func WithTracerProvider(tp trace.TracerProvider) ConfigOption {
 	return func(c config) config {
-		c.TracerProvider = tp
+		c.tracerProvider = tp
 		return c
 	}
 }

--- a/model/modelprocessor/config.go
+++ b/model/modelprocessor/config.go
@@ -27,7 +27,7 @@ import (
 type ConfigOption func(config) config
 
 // config allow processors to get optional arguments.
-// The config struct is shared amongt every processor using it, but they may
+// The config struct is shared amongst every processor using it, but they may
 // not each use every option.
 type config struct {
 	TracerProvider trace.TracerProvider

--- a/model/modelprocessor/config.go
+++ b/model/modelprocessor/config.go
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ConfigOption allows passing a functional option when creating a new
+// processor
+type ConfigOption func(config) config
+
+// config allow processors to get optional arguments.
+// The config struct is shared amongt every processor using it, but they may
+// not each use every option.
+type config struct {
+	TracerProvider trace.TracerProvider
+}
+
+func newConfig(opts ...ConfigOption) config {
+	config := config{}
+	for _, opt := range opts {
+		config = opt(config)
+	}
+
+	if config.TracerProvider == nil {
+		config.TracerProvider = otel.GetTracerProvider()
+	}
+
+	return config
+}
+
+// WithTracerProvider allows setting a custom tracer provider
+// Defaults to the global tracer provider
+func WithTracerProvider(tp trace.TracerProvider) ConfigOption {
+	return func(c config) config {
+		c.TracerProvider = tp
+		return c
+	}
+}

--- a/model/modelprocessor/config_test.go
+++ b/model/modelprocessor/config_test.go
@@ -1,17 +1,19 @@
-// ELASTICSEARCH CONFIDENTIAL
-// __________________
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Copyright Elasticsearch B.V. All rights reserved.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// NOTICE:  All information contained herein is, and remains
-// the property of Elasticsearch B.V. and its suppliers, if any.
-// The intellectual and technical concepts contained herein
-// are proprietary to Elasticsearch B.V. and its suppliers and
-// may be covered by U.S. and Foreign Patents, patents in
-// process, and are protected by trade secret or copyright
-// law.  Dissemination of this information or reproduction of
-// this material is strictly forbidden unless prior written
-// permission is obtained from Elasticsearch B.V.
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package modelprocessor
 

--- a/model/modelprocessor/config_test.go
+++ b/model/modelprocessor/config_test.go
@@ -36,7 +36,7 @@ func TestConfigOptions(t *testing.T) {
 		{
 			name: "with no option",
 			expectedConfig: config{
-				TracerProvider: otel.GetTracerProvider(),
+				tracerProvider: otel.GetTracerProvider(),
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestConfigOptions(t *testing.T) {
 				WithTracerProvider(tp),
 			},
 			expectedConfig: config{
-				TracerProvider: tp,
+				tracerProvider: tp,
 			},
 		},
 	} {

--- a/model/modelprocessor/config_test.go
+++ b/model/modelprocessor/config_test.go
@@ -1,0 +1,55 @@
+// ELASTICSEARCH CONFIDENTIAL
+// __________________
+//
+//  Copyright Elasticsearch B.V. All rights reserved.
+//
+// NOTICE:  All information contained herein is, and remains
+// the property of Elasticsearch B.V. and its suppliers, if any.
+// The intellectual and technical concepts contained herein
+// are proprietary to Elasticsearch B.V. and its suppliers and
+// may be covered by U.S. and Foreign Patents, patents in
+// process, and are protected by trade secret or copyright
+// law.  Dissemination of this information or reproduction of
+// this material is strictly forbidden unless prior written
+// permission is obtained from Elasticsearch B.V.
+
+package modelprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestConfigOptions(t *testing.T) {
+	tp := trace.NewTracerProvider()
+
+	for _, tt := range []struct {
+		name           string
+		opts           []ConfigOption
+		expectedConfig config
+	}{
+		{
+			name: "with no option",
+			expectedConfig: config{
+				TracerProvider: otel.GetTracerProvider(),
+			},
+		},
+		{
+			name: "a custom tracer provider",
+			opts: []ConfigOption{
+				WithTracerProvider(tp),
+			},
+			expectedConfig: config{
+				TracerProvider: tp,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newConfig(tt.opts...)
+			assert.Equal(t, tt.expectedConfig, cfg)
+		})
+	}
+}

--- a/model/modelprocessor/tracer.go
+++ b/model/modelprocessor/tracer.go
@@ -31,10 +31,9 @@ const instrumentationName = "github.com/elastic/apm-data/model/modelprocessor"
 // Tracer is a model.BatchProcessor that wraps another processor within a
 // transaction.
 type Tracer struct {
-	spanName  string
+	tracer    trace.Tracer
 	processor modelpb.BatchProcessor
-
-	tracer trace.Tracer
+	spanName  string
 }
 
 // NewTracer returns a Tracer that emits transactions for batches processed.

--- a/model/modelprocessor/tracer.go
+++ b/model/modelprocessor/tracer.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+const instrumentationName = "github.com/elastic/apm-data/model/modelprocessor"
+
+// Tracer is a model.BatchProcessor that wraps another processor within a
+// transaction.
+type Tracer struct {
+	spanName  string
+	processor modelpb.BatchProcessor
+
+	tracer trace.Tracer
+}
+
+// NewTracer returns a Tracer that emits transactions for batches processed.
+func NewTracer(n string, p modelpb.BatchProcessor, opts ...ConfigOption) *Tracer {
+	cfg := newConfig(opts...)
+
+	return &Tracer{
+		spanName:  n,
+		processor: p,
+
+		tracer: cfg.TracerProvider.Tracer(instrumentationName),
+	}
+}
+
+// ProcessBatch runs for each batch run, and emits telemetry
+func (c *Tracer) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+	ctx, span := c.tracer.Start(ctx, c.spanName)
+	defer span.End()
+
+	err := c.processor.ProcessBatch(ctx, b)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	}
+
+	return err
+}

--- a/model/modelprocessor/tracer.go
+++ b/model/modelprocessor/tracer.go
@@ -44,7 +44,7 @@ func NewTracer(n string, p modelpb.BatchProcessor, opts ...ConfigOption) *Tracer
 		spanName:  n,
 		processor: p,
 
-		tracer: cfg.TracerProvider.Tracer(instrumentationName),
+		tracer: cfg.tracerProvider.Tracer(instrumentationName),
 	}
 }
 

--- a/model/modelprocessor/tracer_test.go
+++ b/model/modelprocessor/tracer_test.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+func TestTracer(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+
+		processor modelpb.ProcessBatchFunc
+
+		expectedErr error
+	}{
+		{
+			name: "with a successful parent processor",
+
+			processor: func(context.Context, *modelpb.Batch) error {
+				return nil
+			},
+		},
+		{
+			name: "with a failing parent processor",
+
+			processor: func(context.Context, *modelpb.Batch) error {
+				return errors.New("failure")
+			},
+
+			expectedErr: errors.New("failure"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			batch := modelpb.Batch{
+				{},
+				{Processor: modelpb.TransactionProcessor()},
+				{Processor: modelpb.SpanProcessor()},
+				{Processor: modelpb.TransactionProcessor()},
+			}
+
+			exp := tracetest.NewInMemoryExporter()
+			tp := trace.NewTracerProvider(
+				trace.WithSyncer(exp),
+			)
+
+			processor := NewTracer("testSpan", tt.processor, WithTracerProvider(tp))
+			err := processor.ProcessBatch(context.Background(), &batch)
+			assert.Equal(t, tt.expectedErr, err)
+
+			var span tracetest.SpanStub
+			for _, s := range exp.GetSpans() {
+				if s.Name == "testSpan" {
+					span = s
+				}
+			}
+			assert.NotNil(t, span)
+		})
+	}
+}


### PR DESCRIPTION
This introduces the same modelprocessor as we have in apm-server: https://github.com/elastic/apm-server/blob/main/internal/model/modelprocessor/tracer.go

But using OpenTelemetry instead of the elastic agent.