### PR TITLE
Require Go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/apm-data
 
-go 1.19
+go 1.20
 
 require (
 	github.com/gofrs/uuid v4.3.1+incompatible


### PR DESCRIPTION
This upgrades to Go 1.20, so we can use slice-to-array conversion in #110.