### PR TITLE
Fix nil session when creating a log event

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -108,6 +108,7 @@ func (c *Consumer) convertLogRecord(
 	event.Event.Severity = int64(record.SeverityNumber())
 	event.Log = populateNil(event.Log)
 	event.Log.Level = record.SeverityText()
+	event.Session = populateNil(event.Session)
 	if body := record.Body(); body.Type() != pcommon.ValueTypeEmpty {
 		event.Message = body.AsString()
 		if body.Type() == pcommon.ValueTypeMap {

--- a/input/otlp/logs_test.go
+++ b/input/otlp/logs_test.go
@@ -69,6 +69,7 @@ func TestConsumerConsumeLogs(t *testing.T) {
 	})
 
 	commonEvent := modelpb.APMEvent{
+		Session: &modelpb.Session{},
 		Agent: &modelpb.Agent{
 			Name:    "otlp/go",
 			Version: "unknown",
@@ -87,13 +88,97 @@ func TestConsumerConsumeLogs(t *testing.T) {
 		Labels:        modelpb.Labels{},
 		NumericLabels: modelpb.NumericLabels{},
 	}
-	test := func(name string, body interface{}, expectedMessage string) {
-		t.Run(name, func(t *testing.T) {
+
+	for _, tt := range []struct {
+		name  string
+		body  any
+		attrs map[string]string
+
+		expectedEvent *modelpb.APMEvent
+	}{
+		{
+			name: "with a string body",
+			body: "a random log message",
+
+			expectedEvent: &modelpb.APMEvent{
+				Message: "a random log message",
+			},
+		},
+		{
+			name: "with an int body",
+			body: 1234,
+
+			expectedEvent: &modelpb.APMEvent{
+				Message: "1234",
+			},
+		},
+		{
+			name: "with a float body",
+			body: 1234.1234,
+
+			expectedEvent: &modelpb.APMEvent{
+				Message: "1234.1234",
+			},
+		},
+		{
+			name: "with a bool body",
+			body: true,
+
+			expectedEvent: &modelpb.APMEvent{
+				Message: "true",
+			},
+		},
+		{
+			name: "with an event name",
+			body: "a log message",
+
+			attrs: map[string]string{
+				"event.name": "hello_world",
+			},
+
+			expectedEvent: &modelpb.APMEvent{
+				Message: "a log message",
+			},
+		},
+		{
+			name: "with an event domain",
+			body: "a log message",
+
+			attrs: map[string]string{
+				"event.domain": "device",
+			},
+
+			expectedEvent: &modelpb.APMEvent{
+				Message: "a log message",
+			},
+		},
+		{
+			name: "with a session id",
+			body: "a log message",
+
+			attrs: map[string]string{
+				"session.id": "abcd",
+			},
+
+			expectedEvent: &modelpb.APMEvent{
+				Session: &modelpb.Session{
+					Id: "abcd",
+				},
+				Message: "a log message",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
 			logs := plog.NewLogs()
 			resourceLogs := logs.ResourceLogs().AppendEmpty()
 			logs.ResourceLogs().At(0).Resource().Attributes().PutStr(semconv.AttributeTelemetrySDKLanguage, "go")
 			scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
-			newLogRecord(body).CopyTo(scopeLogs.LogRecords().AppendEmpty())
+			record := newLogRecord(tt.body)
+
+			for k, v := range tt.attrs {
+				record.Attributes().PutStr(k, v)
+			}
+			record.CopyTo(scopeLogs.LogRecords().AppendEmpty())
 
 			var processed modelpb.Batch
 			var processor modelpb.ProcessBatchFunc = func(_ context.Context, batch *modelpb.Batch) error {
@@ -118,14 +203,14 @@ func TestConsumerConsumeLogs(t *testing.T) {
 			}
 
 			expected := proto.Clone(&commonEvent).(*modelpb.APMEvent)
-			expected.Message = expectedMessage
+			expected.Message = tt.expectedEvent.Message
+			if tt.expectedEvent.Session != nil {
+				expected.Session = tt.expectedEvent.Session
+			}
+
 			assert.Empty(t, cmp.Diff(modelpb.Batch{expected}, processed, protocmp.Transform()))
 		})
 	}
-	test("string_body", "a random log message", "a random log message")
-	test("int_body", 1234, "1234")
-	test("float_body", 1234.1234, "1234.1234")
-	test("bool_body", true, "true")
 	// TODO(marclop): How to test map body
 }
 
@@ -222,6 +307,7 @@ Caused by: LowLevelException
 	assert.Empty(t, processed[0].NumericLabels)
 	processed[1].Timestamp = nil
 	out := cmp.Diff(&modelpb.APMEvent{
+		Session: &modelpb.Session{},
 		Service: &modelpb.Service{
 			Name: "unknown",
 			Language: &modelpb.Language{


### PR DESCRIPTION
Ingesting OTLP logs with a `session.id` is currently causing panics because `event.Session` is nil. So we need to set it.

> panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xaaaad01d2b2c]
>
> goroutine 3420 [running]:
github.com/elastic/apm-data/input/otlp.(*Consumer).convertLogRecord.func1({0x4000193f30?, 0xf?}, {0x50?})
	github.com/elastic/apm-data@v0.1.1-0.20230717081715-e5765b8f8d89/input/otlp/logs.go:150 +0x14c
go.opentelemetry.io/collector/pdata/pcommon.Map.Range({0x1b0f7d80?}, 0x400334a958)
	go.opentelemetry.io/collector/pdata@v1.0.0-rcv0013/pcommon/map.go:202 +0x88
github.com/elastic/apm-data/input/otlp.(*Consumer).convertLogRecord(0x0?, {0x6000103?}, 0x0?, 0xffffffffffffffff?)
	github.com/elastic/apm-data@v0.1.1-0.20230717081715-e5765b8f8d89/input/otlp/logs.go:135 +0x678
github.com/elastic/apm-data/input/otlp.(*Consumer).convertInstrumentationLibraryLogs(0xffff618b95f8?, {0x400334ab08?}, 0x400044c0c0?, 0xaaaacefcc4e8?, 0x40035708d0)
	github.com/elastic/apm-data@v0.1.1-0.20230717081715-e5765b8f8d89/input/otlp/logs.go:95 +0x70
github.com/elastic/apm-data/input/otlp.(*Consumer).convertResourceLogs(0x40005d2c80?, {0xaaaad029f569?}, {0x4003a0f170?, 0x4003ba8480?, 0xaaaad1fb5c20?}, 0x1?)
	github.com/elastic/apm-data@v0.1.1-0.20230717081715-e5765b8f8d89/input/otlp/logs.go:83 +0x1e4
github.com/elastic/apm-data/input/otlp.(*Consumer).ConsumeLogs(0x40005da600, {0xaaaad0f53c40, 0x4003a0f170}, {0xaaaad0d843a0?})
	github.com/elastic/apm-data@v0.1.1-0.20230717081715-e5765b8f8d89/input/otlp/logs.go:62 +0x21c
github.com/elastic/apm-server/internal/beater/otlp.(*logsService).Export(0x40005be340, {0xaaaad0f53c40, 0x4003a0f170}, {0xaaaacf00f650?})
	github.com/elastic/apm-server/internal/beater/otlp/grpc.go:126 +0x74
go.opentelemetry.io/collector/pdata/plog/plogotlp.rawLogsServer.Export({{0xaaaad0f4aa08?, 0x40005be340?}}, {0xaaaad0f53c40?, 0x4003a0f170?}, 0x4003a0f100?)
	go.opentelemetry.io/collector/pdata@v1.0.0-rcv0013/plog/plogotlp/grpc.go:82 +0xf4
go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/logs/v1._LogsService_Export_Handler.func1({0xaaaad0f53c40, 0x4003a0f170}, {0xaaaad0e6e560?, 0x40035700c0})
	go.opentelemetry.io/collector/pdata@v1.0.0-rcv0013/internal/data/protogen/collector/logs/v1/logs_service.pb.go:311 +0x74
github.com/elastic/apm-server/internal/beater/interceptors.AnonymousRateLimit.func1({0xaaaad0f53c40, 0x4003a0f170}, {0xaaaad0e6e560, 0x40035700c0}, 0xaaaad0d25ea0?, 0x40035701e0)
	github.com/elastic/apm-server/internal/beater/interceptors/ratelimit.go:59 +0x168
google.golang.org/grpc.getChainUnaryHandler.func1({0xaaaad0f53c40, 0x4003a0f170}, {0xaaaad0e6e560, 0x40035700c0})
	google.golang.org/grpc@v1.56.1/server.go:1156 +0xa0
github.com/elastic/apm-server/internal/beater/interceptors.Auth.func1({0xaaaad0f53c40, 0x4003a0f0b0}, {0xaaaad0e6e560, 0x40035700c0}, 0x4003aa9ac0, 0x4003ba8440)
	github.com/elastic/apm-server/internal/beater/interceptors/auth.go:76 +0x284
google.golang.org/grpc.getChainUnaryHandler.func1({0xaaaad0f53c40, 0x4003a0f0b0}, {0xaaaad0e6e560, 0x40035700c0})
	google.golang.org/grpc@v1.56.1/server.go:1156 +0xa0
github.com/elastic/apm-server/internal/beater/interceptors.Timeout.func1({0xaaaad0f53c40?, 0x4003a0f0b0?}, {0xaaaad0e6e560?, 0x40035700c0?}, 0x4003aa9ac0?, 0x40035701e0?)
	github.com/elastic/apm-server/internal/beater/interceptors/timeout.go:40 +0x34
google.golang.org/grpc.getChainUnaryHandler.func1({0xaaaad0f53c40, 0x4003a0f0b0}, {0xaaaad0e6e560, 0x40035700c0})
	google.golang.org/grpc@v1.56.1/server.go:1156 +0xa0
github.com/elastic/apm-server/internal/beater/interceptors.Metrics.func1({0xaaaad0f53c40, 0x4003a0f0b0}, {0xaaaad0e6e560, 0x40035700c0}, 0x4003aa9ac0, 0x4003ba83c0)
	github.com/elastic/apm-server/internal/beater/interceptors/metrics.go:83 +0x17c
google.golang.org/grpc.getChainUnaryHandler.func1({0xaaaad0f53c40, 0x4003a0f0b0}, {0xaaaad0e6e560, 0x40035700c0})
	google.golang.org/grpc@v1.56.1/server.go:1156 +0xa0
github.com/elastic/apm-server/internal/beater/interceptors.Logging.func1({0xaaaad0f53c40, 0x4003a0f0b0}, {0xaaaad0e6e560, 0x40035700c0}, 0x4003aa9ac0, 0x4003ba8380)
	github.com/elastic/apm-server/internal/beater/interceptors/logging.go:54 +0x164
google.golang.org/grpc.getChainUnaryHandler.func1({0xaaaad0f53c40, 0x4003a0f0b0}, {0xaaaad0e6e560, 0x40035700c0})
	google.golang.org/grpc@v1.56.1/server.go:1156 +0xa0
github.com/elastic/apm-server/internal/beater/interceptors.ClientMetadata.func1({0xaaaad0f53c40, 0x4003a0ee10}, {0xaaaad0e6e560, 0x40035700c0}, 0x4003aa9ac0?, 0x4003ba8340)
	github.com/elastic/apm-server/internal/beater/interceptors/metadata.go:66 +0x230
google.golang.org/grpc.getChainUnaryHandler.func1({0xaaaad0f53c40, 0x4003a0ee10}, {0xaaaad0e6e560, 0x40035700c0})
	google.golang.org/grpc@v1.56.1/server.go:1156 +0xa0
go.elastic.co/apm/module/apmgrpc/v2.NewUnaryServerInterceptor.func1({0xaaaad0f53c40?, 0x4003a0ee10?}, {0xaaaad0e6e560?, 0x40035700c0?}, 0x4003aa9ac0?, 0x40035701e0?)
	go.elastic.co/apm/module/apmgrpc/v2@v2.2.0/server.go:71 +0xc8
google.golang.org/grpc.chainUnaryInterceptors.func1({0xaaaad0f53c40, 0x4003a0ee10}, {0xaaaad0e6e560, 0x40035700c0}, 0x4000097a38?, 0xaaaacf56cc68?)
	google.golang.org/grpc@v1.56.1/server.go:1147 +0x88
go.opentelemetry.io/collector/pdata/internal/data/protogen/collector/logs/v1._LogsService_Export_Handler({0xaaaad0c695e0?, 0x400035ecc0}, {0xaaaad0f53c40, 0x4003a0ee10}, 0x40005bd490, 0x400025b760)
	go.opentelemetry.io/collector/pdata@v1.0.0-rcv0013/internal/data/protogen/collector/logs/v1/logs_service.pb.go:313 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0x40001fe5a0, {0xaaaad0f5c180, 0x4000509860}, 0x4000499680, 0x40000245d0, 0xaaaad1f845d0, 0x0)
	google.golang.org/grpc@v1.56.1/server.go:1337 +0xc90
google.golang.org/grpc.(*Server).handleStream(0x40001fe5a0, {0xaaaad0f5c180, 0x4000509860}, 0x4000499680, 0x0)
	google.golang.org/grpc@v1.56.1/server.go:1714 +0x82c
google.golang.org/grpc.(*Server).serveStreams.func1.1()
	google.golang.org/grpc@v1.56.1/server.go:959 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.56.1/server.go:957 +0x16c
[event: pod apm-server-apm-server-5dcdfd9f6d-8lqz2] Container image "apm-server:tilt-5a8f0fcecbfebf04" already present on machine
     ┊ Scheduled       - <1s
     ┊ Initialized     - <1s
     ┊ Ready           - 2m30s
[event: apmserver apm-server] The standalone APM Server binary is deprecated as of version 8.0.0 and will be removed in a future release. Consider using Elastic Agent in Fleet-managed mode.
[event: apmserver apm-server] Apm Server health degraded
[event: apmserver apm-server] The standalone APM Server binary is deprecated as of version 8.0.0 and will be removed in a future release. Consider using Elastic Agent in Fleet-managed mode.
[event: apmserver apm-server] The standalone APM Server binary is deprecated as of version 8.0.0 and will be removed in a future release. Consider using Elastic Agent in Fleet-managed mode.
Detected container restart. Pod: apm-server-apm-server-5dcdfd9f6d-8lqz2. Container: apm-server.