### PR TITLE
Only set a session if we have an id

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -108,7 +108,6 @@ func (c *Consumer) convertLogRecord(
 	event.Event.Severity = int64(record.SeverityNumber())
 	event.Log = populateNil(event.Log)
 	event.Log.Level = record.SeverityText()
-	event.Session = populateNil(event.Session)
 	if body := record.Body(); body.Type() != pcommon.ValueTypeEmpty {
 		event.Message = body.AsString()
 		if body.Type() == pcommon.ValueTypeMap {
@@ -147,6 +146,7 @@ func (c *Consumer) convertLogRecord(
 		case "event.domain":
 			eventDomain = v.Str()
 		case "session.id":
+			event.Session = populateNil(event.Session)
 			event.Session.Id = v.Str()
 		default:
 			setLabel(replaceDots(k), event, ifaceAttributeValue(v))

--- a/input/otlp/logs_test.go
+++ b/input/otlp/logs_test.go
@@ -69,7 +69,6 @@ func TestConsumerConsumeLogs(t *testing.T) {
 	})
 
 	commonEvent := modelpb.APMEvent{
-		Session: &modelpb.Session{},
 		Agent: &modelpb.Agent{
 			Name:    "otlp/go",
 			Version: "unknown",
@@ -307,7 +306,6 @@ Caused by: LowLevelException
 	assert.Empty(t, processed[0].NumericLabels)
 	processed[1].Timestamp = nil
 	out := cmp.Diff(&modelpb.APMEvent{
-		Session: &modelpb.Session{},
 		Service: &modelpb.Service{
 			Name: "unknown",
 			Language: &modelpb.Language{


### PR DESCRIPTION
So we avoid empty session objects.
See https://github.com/elastic/apm-server/pull/11241#discussion_r1266866573

Note: I'm not sure this one needs a backport to 8.9. That version will have the extraneous object, but is it a bug?