### PR TITLE
Generate pool methods for proto structs

### DIFF
--- a/model/modelpb/agent_vtproto.pb.go
+++ b/model/modelpb/agent_vtproto.pb.go
@@ -25,6 +25,7 @@ import (
 	fmt "fmt"
 	io "io"
 	bits "math/bits"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -129,6 +130,25 @@ func encodeVarint(dAtA []byte, offset int, v uint64) int {
 	}
 	dAtA[offset] = uint8(v)
 	return base
+}
+
+var vtprotoPool_Agent = sync.Pool{
+	New: func() interface{} {
+		return &Agent{}
+	},
+}
+
+func (m *Agent) ResetVT() {
+	m.Reset()
+}
+func (m *Agent) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Agent.Put(m)
+	}
+}
+func AgentFromVTPool() *Agent {
+	return vtprotoPool_Agent.Get().(*Agent)
 }
 func (m *Agent) SizeVT() (n int) {
 	if m == nil {

--- a/model/modelpb/apmevent_vtproto.pb.go
+++ b/model/modelpb/apmevent_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -537,6 +538,53 @@ func (m *APMEvent) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_APMEvent = sync.Pool{
+	New: func() interface{} {
+		return &APMEvent{}
+	},
+}
+
+func (m *APMEvent) ResetVT() {
+	m.Span.ReturnToVTPool()
+	m.Transaction.ReturnToVTPool()
+	m.Metricset.ReturnToVTPool()
+	m.Error.ReturnToVTPool()
+	m.Cloud.ReturnToVTPool()
+	m.Service.ReturnToVTPool()
+	m.Faas.ReturnToVTPool()
+	m.Network.ReturnToVTPool()
+	m.Container.ReturnToVTPool()
+	m.User.ReturnToVTPool()
+	m.Device.ReturnToVTPool()
+	m.Kubernetes.ReturnToVTPool()
+	m.Observer.ReturnToVTPool()
+	m.DataStream.ReturnToVTPool()
+	m.Agent.ReturnToVTPool()
+	m.Http.ReturnToVTPool()
+	m.UserAgent.ReturnToVTPool()
+	m.Trace.ReturnToVTPool()
+	m.Host.ReturnToVTPool()
+	m.Url.ReturnToVTPool()
+	m.Log.ReturnToVTPool()
+	m.Source.ReturnToVTPool()
+	m.Client.ReturnToVTPool()
+	f0 := m.ChildIds[:0]
+	m.Destination.ReturnToVTPool()
+	m.Session.ReturnToVTPool()
+	m.Process.ReturnToVTPool()
+	m.Event.ReturnToVTPool()
+	m.Reset()
+	m.ChildIds = f0
+}
+func (m *APMEvent) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_APMEvent.Put(m)
+	}
+}
+func APMEventFromVTPool() *APMEvent {
+	return vtprotoPool_APMEvent.Get().(*APMEvent)
+}
 func (m *APMEvent) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -808,7 +856,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Span == nil {
-				m.Span = &Span{}
+				m.Span = SpanFromVTPool()
 			}
 			if err := m.Span.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1102,7 +1150,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Transaction == nil {
-				m.Transaction = &Transaction{}
+				m.Transaction = TransactionFromVTPool()
 			}
 			if err := m.Transaction.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1138,7 +1186,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Metricset == nil {
-				m.Metricset = &Metricset{}
+				m.Metricset = MetricsetFromVTPool()
 			}
 			if err := m.Metricset.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1174,7 +1222,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Error == nil {
-				m.Error = &Error{}
+				m.Error = ErrorFromVTPool()
 			}
 			if err := m.Error.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1210,7 +1258,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Cloud == nil {
-				m.Cloud = &Cloud{}
+				m.Cloud = CloudFromVTPool()
 			}
 			if err := m.Cloud.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1246,7 +1294,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Service == nil {
-				m.Service = &Service{}
+				m.Service = ServiceFromVTPool()
 			}
 			if err := m.Service.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1282,7 +1330,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Faas == nil {
-				m.Faas = &Faas{}
+				m.Faas = FaasFromVTPool()
 			}
 			if err := m.Faas.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1318,7 +1366,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Network == nil {
-				m.Network = &Network{}
+				m.Network = NetworkFromVTPool()
 			}
 			if err := m.Network.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1354,7 +1402,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Container == nil {
-				m.Container = &Container{}
+				m.Container = ContainerFromVTPool()
 			}
 			if err := m.Container.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1390,7 +1438,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.User == nil {
-				m.User = &User{}
+				m.User = UserFromVTPool()
 			}
 			if err := m.User.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1426,7 +1474,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Device == nil {
-				m.Device = &Device{}
+				m.Device = DeviceFromVTPool()
 			}
 			if err := m.Device.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1462,7 +1510,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Kubernetes == nil {
-				m.Kubernetes = &Kubernetes{}
+				m.Kubernetes = KubernetesFromVTPool()
 			}
 			if err := m.Kubernetes.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1498,7 +1546,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Observer == nil {
-				m.Observer = &Observer{}
+				m.Observer = ObserverFromVTPool()
 			}
 			if err := m.Observer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1534,7 +1582,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.DataStream == nil {
-				m.DataStream = &DataStream{}
+				m.DataStream = DataStreamFromVTPool()
 			}
 			if err := m.DataStream.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1570,7 +1618,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Agent == nil {
-				m.Agent = &Agent{}
+				m.Agent = AgentFromVTPool()
 			}
 			if err := m.Agent.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1606,7 +1654,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Http == nil {
-				m.Http = &HTTP{}
+				m.Http = HTTPFromVTPool()
 			}
 			if err := m.Http.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1642,7 +1690,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.UserAgent == nil {
-				m.UserAgent = &UserAgent{}
+				m.UserAgent = UserAgentFromVTPool()
 			}
 			if err := m.UserAgent.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1742,7 +1790,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Trace == nil {
-				m.Trace = &Trace{}
+				m.Trace = TraceFromVTPool()
 			}
 			if err := m.Trace.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1778,7 +1826,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Host == nil {
-				m.Host = &Host{}
+				m.Host = HostFromVTPool()
 			}
 			if err := m.Host.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1814,7 +1862,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Url == nil {
-				m.Url = &URL{}
+				m.Url = URLFromVTPool()
 			}
 			if err := m.Url.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1850,7 +1898,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Log == nil {
-				m.Log = &Log{}
+				m.Log = LogFromVTPool()
 			}
 			if err := m.Log.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1886,7 +1934,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Source == nil {
-				m.Source = &Source{}
+				m.Source = SourceFromVTPool()
 			}
 			if err := m.Source.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1922,7 +1970,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Client == nil {
-				m.Client = &Client{}
+				m.Client = ClientFromVTPool()
 			}
 			if err := m.Client.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1990,7 +2038,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Destination == nil {
-				m.Destination = &Destination{}
+				m.Destination = DestinationFromVTPool()
 			}
 			if err := m.Destination.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2026,7 +2074,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Session == nil {
-				m.Session = &Session{}
+				m.Session = SessionFromVTPool()
 			}
 			if err := m.Session.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2062,7 +2110,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Process == nil {
-				m.Process = &Process{}
+				m.Process = ProcessFromVTPool()
 			}
 			if err := m.Process.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2098,7 +2146,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Event == nil {
-				m.Event = &Event{}
+				m.Event = EventFromVTPool()
 			}
 			if err := m.Event.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/client_vtproto.pb.go
+++ b/model/modelpb/client_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -111,6 +112,25 @@ func (m *Client) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Client = sync.Pool{
+	New: func() interface{} {
+		return &Client{}
+	},
+}
+
+func (m *Client) ResetVT() {
+	m.Ip.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Client) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Client.Put(m)
+	}
+}
+func ClientFromVTPool() *Client {
+	return vtprotoPool_Client.Get().(*Client)
+}
 func (m *Client) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -191,7 +211,7 @@ func (m *Client) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Ip == nil {
-				m.Ip = &IP{}
+				m.Ip = IPFromVTPool()
 			}
 			if err := m.Ip.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/cloud_vtproto.pb.go
+++ b/model/modelpb/cloud_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -267,6 +268,44 @@ func (m *CloudOrigin) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Cloud = sync.Pool{
+	New: func() interface{} {
+		return &Cloud{}
+	},
+}
+
+func (m *Cloud) ResetVT() {
+	m.Origin.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Cloud) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Cloud.Put(m)
+	}
+}
+func CloudFromVTPool() *Cloud {
+	return vtprotoPool_Cloud.Get().(*Cloud)
+}
+
+var vtprotoPool_CloudOrigin = sync.Pool{
+	New: func() interface{} {
+		return &CloudOrigin{}
+	},
+}
+
+func (m *CloudOrigin) ResetVT() {
+	m.Reset()
+}
+func (m *CloudOrigin) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_CloudOrigin.Put(m)
+	}
+}
+func CloudOriginFromVTPool() *CloudOrigin {
+	return vtprotoPool_CloudOrigin.Get().(*CloudOrigin)
+}
 func (m *Cloud) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -410,7 +449,7 @@ func (m *Cloud) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Origin == nil {
-				m.Origin = &CloudOrigin{}
+				m.Origin = CloudOriginFromVTPool()
 			}
 			if err := m.Origin.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/container_vtproto.pb.go
+++ b/model/modelpb/container_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -126,6 +127,24 @@ func (m *Container) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Container = sync.Pool{
+	New: func() interface{} {
+		return &Container{}
+	},
+}
+
+func (m *Container) ResetVT() {
+	m.Reset()
+}
+func (m *Container) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Container.Put(m)
+	}
+}
+func ContainerFromVTPool() *Container {
+	return vtprotoPool_Container.Get().(*Container)
+}
 func (m *Container) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/datastream_vtproto.pb.go
+++ b/model/modelpb/datastream_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -110,6 +111,24 @@ func (m *DataStream) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_DataStream = sync.Pool{
+	New: func() interface{} {
+		return &DataStream{}
+	},
+}
+
+func (m *DataStream) ResetVT() {
+	m.Reset()
+}
+func (m *DataStream) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_DataStream.Put(m)
+	}
+}
+func DataStreamFromVTPool() *DataStream {
+	return vtprotoPool_DataStream.Get().(*DataStream)
+}
 func (m *DataStream) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/destination_vtproto.pb.go
+++ b/model/modelpb/destination_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -100,6 +101,24 @@ func (m *Destination) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Destination = sync.Pool{
+	New: func() interface{} {
+		return &Destination{}
+	},
+}
+
+func (m *Destination) ResetVT() {
+	m.Reset()
+}
+func (m *Destination) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Destination.Put(m)
+	}
+}
+func DestinationFromVTPool() *Destination {
+	return vtprotoPool_Destination.Get().(*Destination)
+}
 func (m *Destination) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/device_vtproto.pb.go
+++ b/model/modelpb/device_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -179,6 +180,44 @@ func (m *DeviceModel) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Device = sync.Pool{
+	New: func() interface{} {
+		return &Device{}
+	},
+}
+
+func (m *Device) ResetVT() {
+	m.Model.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Device) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Device.Put(m)
+	}
+}
+func DeviceFromVTPool() *Device {
+	return vtprotoPool_Device.Get().(*Device)
+}
+
+var vtprotoPool_DeviceModel = sync.Pool{
+	New: func() interface{} {
+		return &DeviceModel{}
+	},
+}
+
+func (m *DeviceModel) ResetVT() {
+	m.Reset()
+}
+func (m *DeviceModel) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_DeviceModel.Put(m)
+	}
+}
+func DeviceModelFromVTPool() *DeviceModel {
+	return vtprotoPool_DeviceModel.Get().(*DeviceModel)
+}
 func (m *Device) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -310,7 +349,7 @@ func (m *Device) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Model == nil {
-				m.Model = &DeviceModel{}
+				m.Model = DeviceModelFromVTPool()
 			}
 			if err := m.Model.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/error_vtproto.pb.go
+++ b/model/modelpb/error_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -429,6 +430,79 @@ func (m *ErrorLog) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Error = sync.Pool{
+	New: func() interface{} {
+		return &Error{}
+	},
+}
+
+func (m *Error) ResetVT() {
+	for _, mm := range m.Custom {
+		mm.ResetVT()
+	}
+	m.Exception.ReturnToVTPool()
+	m.Log.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Error) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Error.Put(m)
+	}
+}
+func ErrorFromVTPool() *Error {
+	return vtprotoPool_Error.Get().(*Error)
+}
+
+var vtprotoPool_Exception = sync.Pool{
+	New: func() interface{} {
+		return &Exception{}
+	},
+}
+
+func (m *Exception) ResetVT() {
+	for _, mm := range m.Attributes {
+		mm.ResetVT()
+	}
+	for _, mm := range m.Stacktrace {
+		mm.ResetVT()
+	}
+	for _, mm := range m.Cause {
+		mm.ResetVT()
+	}
+	m.Reset()
+}
+func (m *Exception) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Exception.Put(m)
+	}
+}
+func ExceptionFromVTPool() *Exception {
+	return vtprotoPool_Exception.Get().(*Exception)
+}
+
+var vtprotoPool_ErrorLog = sync.Pool{
+	New: func() interface{} {
+		return &ErrorLog{}
+	},
+}
+
+func (m *ErrorLog) ResetVT() {
+	for _, mm := range m.Stacktrace {
+		mm.ResetVT()
+	}
+	m.Reset()
+}
+func (m *ErrorLog) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_ErrorLog.Put(m)
+	}
+}
+func ErrorLogFromVTPool() *ErrorLog {
+	return vtprotoPool_ErrorLog.Get().(*ErrorLog)
+}
 func (m *Error) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -614,7 +688,14 @@ func (m *Error) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Custom = append(m.Custom, &KeyValue{})
+			if len(m.Custom) == cap(m.Custom) {
+				m.Custom = append(m.Custom, &KeyValue{})
+			} else {
+				m.Custom = m.Custom[:len(m.Custom)+1]
+				if m.Custom[len(m.Custom)-1] == nil {
+					m.Custom[len(m.Custom)-1] = &KeyValue{}
+				}
+			}
 			if err := m.Custom[len(m.Custom)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -649,7 +730,7 @@ func (m *Error) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Exception == nil {
-				m.Exception = &Exception{}
+				m.Exception = ExceptionFromVTPool()
 			}
 			if err := m.Exception.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -685,7 +766,7 @@ func (m *Error) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Log == nil {
-				m.Log = &ErrorLog{}
+				m.Log = ErrorLogFromVTPool()
 			}
 			if err := m.Log.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1059,7 +1140,14 @@ func (m *Exception) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Attributes = append(m.Attributes, &KeyValue{})
+			if len(m.Attributes) == cap(m.Attributes) {
+				m.Attributes = append(m.Attributes, &KeyValue{})
+			} else {
+				m.Attributes = m.Attributes[:len(m.Attributes)+1]
+				if m.Attributes[len(m.Attributes)-1] == nil {
+					m.Attributes[len(m.Attributes)-1] = &KeyValue{}
+				}
+			}
 			if err := m.Attributes[len(m.Attributes)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1093,7 +1181,14 @@ func (m *Exception) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
+			if len(m.Stacktrace) == cap(m.Stacktrace) {
+				m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
+			} else {
+				m.Stacktrace = m.Stacktrace[:len(m.Stacktrace)+1]
+				if m.Stacktrace[len(m.Stacktrace)-1] == nil {
+					m.Stacktrace[len(m.Stacktrace)-1] = &StacktraceFrame{}
+				}
+			}
 			if err := m.Stacktrace[len(m.Stacktrace)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1180,7 +1275,14 @@ func (m *Exception) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Cause = append(m.Cause, &Exception{})
+			if len(m.Cause) == cap(m.Cause) {
+				m.Cause = append(m.Cause, &Exception{})
+			} else {
+				m.Cause = m.Cause[:len(m.Cause)+1]
+				if m.Cause[len(m.Cause)-1] == nil {
+					m.Cause[len(m.Cause)-1] = &Exception{}
+				}
+			}
 			if err := m.Cause[len(m.Cause)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1393,7 +1495,14 @@ func (m *ErrorLog) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
+			if len(m.Stacktrace) == cap(m.Stacktrace) {
+				m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
+			} else {
+				m.Stacktrace = m.Stacktrace[:len(m.Stacktrace)+1]
+				if m.Stacktrace[len(m.Stacktrace)-1] == nil {
+					m.Stacktrace[len(m.Stacktrace)-1] = &StacktraceFrame{}
+				}
+			}
 			if err := m.Stacktrace[len(m.Stacktrace)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/model/modelpb/event_vtproto.pb.go
+++ b/model/modelpb/event_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -211,6 +212,25 @@ func (m *Event) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Event = sync.Pool{
+	New: func() interface{} {
+		return &Event{}
+	},
+}
+
+func (m *Event) ResetVT() {
+	m.SuccessCount.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Event) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Event.Put(m)
+	}
+}
+func EventFromVTPool() *Event {
+	return vtprotoPool_Event.Get().(*Event)
+}
 func (m *Event) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -523,7 +543,7 @@ func (m *Event) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.SuccessCount == nil {
-				m.SuccessCount = &SummaryMetric{}
+				m.SuccessCount = SummaryMetricFromVTPool()
 			}
 			if err := m.SuccessCount.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/experience_vtproto.pb.go
+++ b/model/modelpb/experience_vtproto.pb.go
@@ -26,6 +26,7 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -190,6 +191,44 @@ func (m *LongtaskMetrics) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_UserExperience = sync.Pool{
+	New: func() interface{} {
+		return &UserExperience{}
+	},
+}
+
+func (m *UserExperience) ResetVT() {
+	m.LongTask.ReturnToVTPool()
+	m.Reset()
+}
+func (m *UserExperience) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_UserExperience.Put(m)
+	}
+}
+func UserExperienceFromVTPool() *UserExperience {
+	return vtprotoPool_UserExperience.Get().(*UserExperience)
+}
+
+var vtprotoPool_LongtaskMetrics = sync.Pool{
+	New: func() interface{} {
+		return &LongtaskMetrics{}
+	},
+}
+
+func (m *LongtaskMetrics) ResetVT() {
+	m.Reset()
+}
+func (m *LongtaskMetrics) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_LongtaskMetrics.Put(m)
+	}
+}
+func LongtaskMetricsFromVTPool() *LongtaskMetrics {
+	return vtprotoPool_LongtaskMetrics.Get().(*LongtaskMetrics)
+}
 func (m *UserExperience) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -324,7 +363,7 @@ func (m *UserExperience) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.LongTask == nil {
-				m.LongTask = &LongtaskMetrics{}
+				m.LongTask = LongtaskMetricsFromVTPool()
 			}
 			if err := m.LongTask.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/faas_vtproto.pb.go
+++ b/model/modelpb/faas_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -148,6 +149,24 @@ func (m *Faas) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Faas = sync.Pool{
+	New: func() interface{} {
+		return &Faas{}
+	},
+}
+
+func (m *Faas) ResetVT() {
+	m.Reset()
+}
+func (m *Faas) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Faas.Put(m)
+	}
+}
+func FaasFromVTPool() *Faas {
+	return vtprotoPool_Faas.Get().(*Faas)
+}
 func (m *Faas) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/headers_vtproto.pb.go
+++ b/model/modelpb/headers_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -108,6 +109,26 @@ func (m *HTTPHeader) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_HTTPHeader = sync.Pool{
+	New: func() interface{} {
+		return &HTTPHeader{}
+	},
+}
+
+func (m *HTTPHeader) ResetVT() {
+	f0 := m.Value[:0]
+	m.Reset()
+	m.Value = f0
+}
+func (m *HTTPHeader) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_HTTPHeader.Put(m)
+	}
+}
+func HTTPHeaderFromVTPool() *HTTPHeader {
+	return vtprotoPool_HTTPHeader.Get().(*HTTPHeader)
+}
 func (m *HTTPHeader) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/http_vtproto.pb.go
+++ b/model/modelpb/http_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -407,6 +408,76 @@ func (m *HTTPResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_HTTP = sync.Pool{
+	New: func() interface{} {
+		return &HTTP{}
+	},
+}
+
+func (m *HTTP) ResetVT() {
+	m.Request.ReturnToVTPool()
+	m.Response.ReturnToVTPool()
+	m.Reset()
+}
+func (m *HTTP) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_HTTP.Put(m)
+	}
+}
+func HTTPFromVTPool() *HTTP {
+	return vtprotoPool_HTTP.Get().(*HTTP)
+}
+
+var vtprotoPool_HTTPRequest = sync.Pool{
+	New: func() interface{} {
+		return &HTTPRequest{}
+	},
+}
+
+func (m *HTTPRequest) ResetVT() {
+	for _, mm := range m.Headers {
+		mm.ResetVT()
+	}
+	for _, mm := range m.Env {
+		mm.ResetVT()
+	}
+	for _, mm := range m.Cookies {
+		mm.ResetVT()
+	}
+	m.Reset()
+}
+func (m *HTTPRequest) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_HTTPRequest.Put(m)
+	}
+}
+func HTTPRequestFromVTPool() *HTTPRequest {
+	return vtprotoPool_HTTPRequest.Get().(*HTTPRequest)
+}
+
+var vtprotoPool_HTTPResponse = sync.Pool{
+	New: func() interface{} {
+		return &HTTPResponse{}
+	},
+}
+
+func (m *HTTPResponse) ResetVT() {
+	for _, mm := range m.Headers {
+		mm.ResetVT()
+	}
+	m.Reset()
+}
+func (m *HTTPResponse) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_HTTPResponse.Put(m)
+	}
+}
+func HTTPResponseFromVTPool() *HTTPResponse {
+	return vtprotoPool_HTTPResponse.Get().(*HTTPResponse)
+}
 func (m *HTTP) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -572,7 +643,7 @@ func (m *HTTP) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Request == nil {
-				m.Request = &HTTPRequest{}
+				m.Request = HTTPRequestFromVTPool()
 			}
 			if err := m.Request.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -608,7 +679,7 @@ func (m *HTTP) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Response == nil {
-				m.Response = &HTTPResponse{}
+				m.Response = HTTPResponseFromVTPool()
 			}
 			if err := m.Response.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -770,7 +841,14 @@ func (m *HTTPRequest) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Headers = append(m.Headers, &HTTPHeader{})
+			if len(m.Headers) == cap(m.Headers) {
+				m.Headers = append(m.Headers, &HTTPHeader{})
+			} else {
+				m.Headers = m.Headers[:len(m.Headers)+1]
+				if m.Headers[len(m.Headers)-1] == nil {
+					m.Headers[len(m.Headers)-1] = &HTTPHeader{}
+				}
+			}
 			if err := m.Headers[len(m.Headers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -804,7 +882,14 @@ func (m *HTTPRequest) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Env = append(m.Env, &KeyValue{})
+			if len(m.Env) == cap(m.Env) {
+				m.Env = append(m.Env, &KeyValue{})
+			} else {
+				m.Env = m.Env[:len(m.Env)+1]
+				if m.Env[len(m.Env)-1] == nil {
+					m.Env[len(m.Env)-1] = &KeyValue{}
+				}
+			}
 			if err := m.Env[len(m.Env)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -838,7 +923,14 @@ func (m *HTTPRequest) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Cookies = append(m.Cookies, &KeyValue{})
+			if len(m.Cookies) == cap(m.Cookies) {
+				m.Cookies = append(m.Cookies, &KeyValue{})
+			} else {
+				m.Cookies = m.Cookies[:len(m.Cookies)+1]
+				if m.Cookies[len(m.Cookies)-1] == nil {
+					m.Cookies[len(m.Cookies)-1] = &KeyValue{}
+				}
+			}
 			if err := m.Cookies[len(m.Cookies)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1019,7 +1111,14 @@ func (m *HTTPResponse) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Headers = append(m.Headers, &HTTPHeader{})
+			if len(m.Headers) == cap(m.Headers) {
+				m.Headers = append(m.Headers, &HTTPHeader{})
+			} else {
+				m.Headers = m.Headers[:len(m.Headers)+1]
+				if m.Headers[len(m.Headers)-1] == nil {
+					m.Headers[len(m.Headers)-1] = &HTTPHeader{}
+				}
+			}
 			if err := m.Headers[len(m.Headers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/model/modelpb/ip_vtproto.pb.go
+++ b/model/modelpb/ip_vtproto.pb.go
@@ -25,6 +25,7 @@ import (
 	binary "encoding/binary"
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -106,6 +107,26 @@ func (m *IP) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_IP = sync.Pool{
+	New: func() interface{} {
+		return &IP{}
+	},
+}
+
+func (m *IP) ResetVT() {
+	f0 := m.V6[:0]
+	m.Reset()
+	m.V6 = f0
+}
+func (m *IP) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_IP.Put(m)
+	}
+}
+func IPFromVTPool() *IP {
+	return vtprotoPool_IP.Get().(*IP)
+}
 func (m *IP) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/keyvalue_vtproto.pb.go
+++ b/model/modelpb/keyvalue_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -124,6 +125,24 @@ func (m *KeyValue) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_KeyValue = sync.Pool{
+	New: func() interface{} {
+		return &KeyValue{}
+	},
+}
+
+func (m *KeyValue) ResetVT() {
+	m.Reset()
+}
+func (m *KeyValue) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_KeyValue.Put(m)
+	}
+}
+func KeyValueFromVTPool() *KeyValue {
+	return vtprotoPool_KeyValue.Get().(*KeyValue)
+}
 func (m *KeyValue) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/kubernetes_vtproto.pb.go
+++ b/model/modelpb/kubernetes_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -118,6 +119,24 @@ func (m *Kubernetes) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Kubernetes = sync.Pool{
+	New: func() interface{} {
+		return &Kubernetes{}
+	},
+}
+
+func (m *Kubernetes) ResetVT() {
+	m.Reset()
+}
+func (m *Kubernetes) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Kubernetes.Put(m)
+	}
+}
+func KubernetesFromVTPool() *Kubernetes {
+	return vtprotoPool_Kubernetes.Get().(*Kubernetes)
+}
 func (m *Kubernetes) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/labels_vtproto.pb.go
+++ b/model/modelpb/labels_vtproto.pb.go
@@ -26,6 +26,7 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -204,6 +205,47 @@ func (m *NumericLabelValue) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_LabelValue = sync.Pool{
+	New: func() interface{} {
+		return &LabelValue{}
+	},
+}
+
+func (m *LabelValue) ResetVT() {
+	f0 := m.Values[:0]
+	m.Reset()
+	m.Values = f0
+}
+func (m *LabelValue) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_LabelValue.Put(m)
+	}
+}
+func LabelValueFromVTPool() *LabelValue {
+	return vtprotoPool_LabelValue.Get().(*LabelValue)
+}
+
+var vtprotoPool_NumericLabelValue = sync.Pool{
+	New: func() interface{} {
+		return &NumericLabelValue{}
+	},
+}
+
+func (m *NumericLabelValue) ResetVT() {
+	f0 := m.Values[:0]
+	m.Reset()
+	m.Values = f0
+}
+func (m *NumericLabelValue) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_NumericLabelValue.Put(m)
+	}
+}
+func NumericLabelValueFromVTPool() *NumericLabelValue {
+	return vtprotoPool_NumericLabelValue.Get().(*NumericLabelValue)
+}
 func (m *LabelValue) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -448,7 +490,7 @@ func (m *NumericLabelValue) UnmarshalVT(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Values) == 0 {
+				if elementCount != 0 && len(m.Values) == 0 && cap(m.Values) < elementCount {
 					m.Values = make([]float64, 0, elementCount)
 				}
 				for iNdEx < postIndex {

--- a/model/modelpb/log_vtproto.pb.go
+++ b/model/modelpb/log_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -246,6 +247,64 @@ func (m *LogOriginFile) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Log = sync.Pool{
+	New: func() interface{} {
+		return &Log{}
+	},
+}
+
+func (m *Log) ResetVT() {
+	m.Origin.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Log) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Log.Put(m)
+	}
+}
+func LogFromVTPool() *Log {
+	return vtprotoPool_Log.Get().(*Log)
+}
+
+var vtprotoPool_LogOrigin = sync.Pool{
+	New: func() interface{} {
+		return &LogOrigin{}
+	},
+}
+
+func (m *LogOrigin) ResetVT() {
+	m.File.ReturnToVTPool()
+	m.Reset()
+}
+func (m *LogOrigin) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_LogOrigin.Put(m)
+	}
+}
+func LogOriginFromVTPool() *LogOrigin {
+	return vtprotoPool_LogOrigin.Get().(*LogOrigin)
+}
+
+var vtprotoPool_LogOriginFile = sync.Pool{
+	New: func() interface{} {
+		return &LogOriginFile{}
+	},
+}
+
+func (m *LogOriginFile) ResetVT() {
+	m.Reset()
+}
+func (m *LogOriginFile) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_LogOriginFile.Put(m)
+	}
+}
+func LogOriginFileFromVTPool() *LogOriginFile {
+	return vtprotoPool_LogOriginFile.Get().(*LogOriginFile)
+}
 func (m *Log) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -426,7 +485,7 @@ func (m *Log) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Origin == nil {
-				m.Origin = &LogOrigin{}
+				m.Origin = LogOriginFromVTPool()
 			}
 			if err := m.Origin.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -545,7 +604,7 @@ func (m *LogOrigin) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.File == nil {
-				m.File = &LogOriginFile{}
+				m.File = LogOriginFileFromVTPool()
 			}
 			if err := m.File.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/network_vtproto.pb.go
+++ b/model/modelpb/network_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -256,6 +257,64 @@ func (m *NetworkCarrier) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Network = sync.Pool{
+	New: func() interface{} {
+		return &Network{}
+	},
+}
+
+func (m *Network) ResetVT() {
+	m.Connection.ReturnToVTPool()
+	m.Carrier.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Network) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Network.Put(m)
+	}
+}
+func NetworkFromVTPool() *Network {
+	return vtprotoPool_Network.Get().(*Network)
+}
+
+var vtprotoPool_NetworkConnection = sync.Pool{
+	New: func() interface{} {
+		return &NetworkConnection{}
+	},
+}
+
+func (m *NetworkConnection) ResetVT() {
+	m.Reset()
+}
+func (m *NetworkConnection) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_NetworkConnection.Put(m)
+	}
+}
+func NetworkConnectionFromVTPool() *NetworkConnection {
+	return vtprotoPool_NetworkConnection.Get().(*NetworkConnection)
+}
+
+var vtprotoPool_NetworkCarrier = sync.Pool{
+	New: func() interface{} {
+		return &NetworkCarrier{}
+	},
+}
+
+func (m *NetworkCarrier) ResetVT() {
+	m.Reset()
+}
+func (m *NetworkCarrier) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_NetworkCarrier.Put(m)
+	}
+}
+func NetworkCarrierFromVTPool() *NetworkCarrier {
+	return vtprotoPool_NetworkCarrier.Get().(*NetworkCarrier)
+}
 func (m *Network) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -377,7 +436,7 @@ func (m *Network) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Connection == nil {
-				m.Connection = &NetworkConnection{}
+				m.Connection = NetworkConnectionFromVTPool()
 			}
 			if err := m.Connection.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -413,7 +472,7 @@ func (m *Network) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Carrier == nil {
-				m.Carrier = &NetworkCarrier{}
+				m.Carrier = NetworkCarrierFromVTPool()
 			}
 			if err := m.Carrier.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/observer_vtproto.pb.go
+++ b/model/modelpb/observer_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -118,6 +119,24 @@ func (m *Observer) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Observer = sync.Pool{
+	New: func() interface{} {
+		return &Observer{}
+	},
+}
+
+func (m *Observer) ResetVT() {
+	m.Reset()
+}
+func (m *Observer) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Observer.Put(m)
+	}
+}
+func ObserverFromVTPool() *Observer {
+	return vtprotoPool_Observer.Get().(*Observer)
+}
 func (m *Observer) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/os_vtproto.pb.go
+++ b/model/modelpb/os_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -126,6 +127,24 @@ func (m *OS) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_OS = sync.Pool{
+	New: func() interface{} {
+		return &OS{}
+	},
+}
+
+func (m *OS) ResetVT() {
+	m.Reset()
+}
+func (m *OS) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_OS.Put(m)
+	}
+}
+func OSFromVTPool() *OS {
+	return vtprotoPool_OS.Get().(*OS)
+}
 func (m *OS) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/process_vtproto.pb.go
+++ b/model/modelpb/process_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -211,6 +212,46 @@ func (m *ProcessThread) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Process = sync.Pool{
+	New: func() interface{} {
+		return &Process{}
+	},
+}
+
+func (m *Process) ResetVT() {
+	m.Thread.ReturnToVTPool()
+	f0 := m.Argv[:0]
+	m.Reset()
+	m.Argv = f0
+}
+func (m *Process) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Process.Put(m)
+	}
+}
+func ProcessFromVTPool() *Process {
+	return vtprotoPool_Process.Get().(*Process)
+}
+
+var vtprotoPool_ProcessThread = sync.Pool{
+	New: func() interface{} {
+		return &ProcessThread{}
+	},
+}
+
+func (m *ProcessThread) ResetVT() {
+	m.Reset()
+}
+func (m *ProcessThread) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_ProcessThread.Put(m)
+	}
+}
+func ProcessThreadFromVTPool() *ProcessThread {
+	return vtprotoPool_ProcessThread.Get().(*ProcessThread)
+}
 func (m *Process) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -344,7 +385,7 @@ func (m *Process) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Thread == nil {
-				m.Thread = &ProcessThread{}
+				m.Thread = ProcessThreadFromVTPool()
 			}
 			if err := m.Thread.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/service_vtproto.pb.go
+++ b/model/modelpb/service_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -572,6 +573,144 @@ func (m *ServiceNode) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Service = sync.Pool{
+	New: func() interface{} {
+		return &Service{}
+	},
+}
+
+func (m *Service) ResetVT() {
+	m.Origin.ReturnToVTPool()
+	m.Target.ReturnToVTPool()
+	m.Language.ReturnToVTPool()
+	m.Runtime.ReturnToVTPool()
+	m.Framework.ReturnToVTPool()
+	m.Node.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Service) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Service.Put(m)
+	}
+}
+func ServiceFromVTPool() *Service {
+	return vtprotoPool_Service.Get().(*Service)
+}
+
+var vtprotoPool_ServiceOrigin = sync.Pool{
+	New: func() interface{} {
+		return &ServiceOrigin{}
+	},
+}
+
+func (m *ServiceOrigin) ResetVT() {
+	m.Reset()
+}
+func (m *ServiceOrigin) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_ServiceOrigin.Put(m)
+	}
+}
+func ServiceOriginFromVTPool() *ServiceOrigin {
+	return vtprotoPool_ServiceOrigin.Get().(*ServiceOrigin)
+}
+
+var vtprotoPool_ServiceTarget = sync.Pool{
+	New: func() interface{} {
+		return &ServiceTarget{}
+	},
+}
+
+func (m *ServiceTarget) ResetVT() {
+	m.Reset()
+}
+func (m *ServiceTarget) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_ServiceTarget.Put(m)
+	}
+}
+func ServiceTargetFromVTPool() *ServiceTarget {
+	return vtprotoPool_ServiceTarget.Get().(*ServiceTarget)
+}
+
+var vtprotoPool_Language = sync.Pool{
+	New: func() interface{} {
+		return &Language{}
+	},
+}
+
+func (m *Language) ResetVT() {
+	m.Reset()
+}
+func (m *Language) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Language.Put(m)
+	}
+}
+func LanguageFromVTPool() *Language {
+	return vtprotoPool_Language.Get().(*Language)
+}
+
+var vtprotoPool_Runtime = sync.Pool{
+	New: func() interface{} {
+		return &Runtime{}
+	},
+}
+
+func (m *Runtime) ResetVT() {
+	m.Reset()
+}
+func (m *Runtime) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Runtime.Put(m)
+	}
+}
+func RuntimeFromVTPool() *Runtime {
+	return vtprotoPool_Runtime.Get().(*Runtime)
+}
+
+var vtprotoPool_Framework = sync.Pool{
+	New: func() interface{} {
+		return &Framework{}
+	},
+}
+
+func (m *Framework) ResetVT() {
+	m.Reset()
+}
+func (m *Framework) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Framework.Put(m)
+	}
+}
+func FrameworkFromVTPool() *Framework {
+	return vtprotoPool_Framework.Get().(*Framework)
+}
+
+var vtprotoPool_ServiceNode = sync.Pool{
+	New: func() interface{} {
+		return &ServiceNode{}
+	},
+}
+
+func (m *ServiceNode) ResetVT() {
+	m.Reset()
+}
+func (m *ServiceNode) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_ServiceNode.Put(m)
+	}
+}
+func ServiceNodeFromVTPool() *ServiceNode {
+	return vtprotoPool_ServiceNode.Get().(*ServiceNode)
+}
 func (m *Service) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -785,7 +924,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Origin == nil {
-				m.Origin = &ServiceOrigin{}
+				m.Origin = ServiceOriginFromVTPool()
 			}
 			if err := m.Origin.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -821,7 +960,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Target == nil {
-				m.Target = &ServiceTarget{}
+				m.Target = ServiceTargetFromVTPool()
 			}
 			if err := m.Target.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -857,7 +996,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Language == nil {
-				m.Language = &Language{}
+				m.Language = LanguageFromVTPool()
 			}
 			if err := m.Language.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -893,7 +1032,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Runtime == nil {
-				m.Runtime = &Runtime{}
+				m.Runtime = RuntimeFromVTPool()
 			}
 			if err := m.Runtime.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -929,7 +1068,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Framework == nil {
-				m.Framework = &Framework{}
+				m.Framework = FrameworkFromVTPool()
 			}
 			if err := m.Framework.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1061,7 +1200,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Node == nil {
-				m.Node = &ServiceNode{}
+				m.Node = ServiceNodeFromVTPool()
 			}
 			if err := m.Node.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/session_vtproto.pb.go
+++ b/model/modelpb/session_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -100,6 +101,24 @@ func (m *Session) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Session = sync.Pool{
+	New: func() interface{} {
+		return &Session{}
+	},
+}
+
+func (m *Session) ResetVT() {
+	m.Reset()
+}
+func (m *Session) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Session.Put(m)
+	}
+}
+func SessionFromVTPool() *Session {
+	return vtprotoPool_Session.Get().(*Session)
+}
 func (m *Session) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/source_vtproto.pb.go
+++ b/model/modelpb/source_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -183,6 +184,46 @@ func (m *NAT) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Source = sync.Pool{
+	New: func() interface{} {
+		return &Source{}
+	},
+}
+
+func (m *Source) ResetVT() {
+	m.Ip.ReturnToVTPool()
+	m.Nat.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Source) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Source.Put(m)
+	}
+}
+func SourceFromVTPool() *Source {
+	return vtprotoPool_Source.Get().(*Source)
+}
+
+var vtprotoPool_NAT = sync.Pool{
+	New: func() interface{} {
+		return &NAT{}
+	},
+}
+
+func (m *NAT) ResetVT() {
+	m.Ip.ReturnToVTPool()
+	m.Reset()
+}
+func (m *NAT) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_NAT.Put(m)
+	}
+}
+func NATFromVTPool() *NAT {
+	return vtprotoPool_NAT.Get().(*NAT)
+}
 func (m *Source) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -281,7 +322,7 @@ func (m *Source) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Ip == nil {
-				m.Ip = &IP{}
+				m.Ip = IPFromVTPool()
 			}
 			if err := m.Ip.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -317,7 +358,7 @@ func (m *Source) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Nat == nil {
-				m.Nat = &NAT{}
+				m.Nat = NATFromVTPool()
 			}
 			if err := m.Nat.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -455,7 +496,7 @@ func (m *NAT) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Ip == nil {
-				m.Ip = &IP{}
+				m.Ip = IPFromVTPool()
 			}
 			if err := m.Ip.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/span_vtproto.pb.go
+++ b/model/modelpb/span_vtproto.pb.go
@@ -26,6 +26,7 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -569,6 +570,112 @@ func (m *SpanLink) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Span = sync.Pool{
+	New: func() interface{} {
+		return &Span{}
+	},
+}
+
+func (m *Span) ResetVT() {
+	m.Message.ReturnToVTPool()
+	m.Composite.ReturnToVTPool()
+	m.DestinationService.ReturnToVTPool()
+	m.Db.ReturnToVTPool()
+	for _, mm := range m.Stacktrace {
+		mm.ResetVT()
+	}
+	for _, mm := range m.Links {
+		mm.ResetVT()
+	}
+	m.SelfTime.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Span) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Span.Put(m)
+	}
+}
+func SpanFromVTPool() *Span {
+	return vtprotoPool_Span.Get().(*Span)
+}
+
+var vtprotoPool_DB = sync.Pool{
+	New: func() interface{} {
+		return &DB{}
+	},
+}
+
+func (m *DB) ResetVT() {
+	m.Reset()
+}
+func (m *DB) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_DB.Put(m)
+	}
+}
+func DBFromVTPool() *DB {
+	return vtprotoPool_DB.Get().(*DB)
+}
+
+var vtprotoPool_DestinationService = sync.Pool{
+	New: func() interface{} {
+		return &DestinationService{}
+	},
+}
+
+func (m *DestinationService) ResetVT() {
+	m.ResponseTime.ReturnToVTPool()
+	m.Reset()
+}
+func (m *DestinationService) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_DestinationService.Put(m)
+	}
+}
+func DestinationServiceFromVTPool() *DestinationService {
+	return vtprotoPool_DestinationService.Get().(*DestinationService)
+}
+
+var vtprotoPool_Composite = sync.Pool{
+	New: func() interface{} {
+		return &Composite{}
+	},
+}
+
+func (m *Composite) ResetVT() {
+	m.Reset()
+}
+func (m *Composite) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Composite.Put(m)
+	}
+}
+func CompositeFromVTPool() *Composite {
+	return vtprotoPool_Composite.Get().(*Composite)
+}
+
+var vtprotoPool_SpanLink = sync.Pool{
+	New: func() interface{} {
+		return &SpanLink{}
+	},
+}
+
+func (m *SpanLink) ResetVT() {
+	m.Reset()
+}
+func (m *SpanLink) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_SpanLink.Put(m)
+	}
+}
+func SpanLinkFromVTPool() *SpanLink {
+	return vtprotoPool_SpanLink.Get().(*SpanLink)
+}
 func (m *Span) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -796,7 +903,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Message == nil {
-				m.Message = &Message{}
+				m.Message = MessageFromVTPool()
 			}
 			if err := m.Message.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -832,7 +939,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Composite == nil {
-				m.Composite = &Composite{}
+				m.Composite = CompositeFromVTPool()
 			}
 			if err := m.Composite.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -868,7 +975,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.DestinationService == nil {
-				m.DestinationService = &DestinationService{}
+				m.DestinationService = DestinationServiceFromVTPool()
 			}
 			if err := m.DestinationService.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -904,7 +1011,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Db == nil {
-				m.Db = &DB{}
+				m.Db = DBFromVTPool()
 			}
 			if err := m.Db.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1152,7 +1259,14 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
+			if len(m.Stacktrace) == cap(m.Stacktrace) {
+				m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
+			} else {
+				m.Stacktrace = m.Stacktrace[:len(m.Stacktrace)+1]
+				if m.Stacktrace[len(m.Stacktrace)-1] == nil {
+					m.Stacktrace[len(m.Stacktrace)-1] = &StacktraceFrame{}
+				}
+			}
 			if err := m.Stacktrace[len(m.Stacktrace)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1186,7 +1300,14 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Links = append(m.Links, &SpanLink{})
+			if len(m.Links) == cap(m.Links) {
+				m.Links = append(m.Links, &SpanLink{})
+			} else {
+				m.Links = m.Links[:len(m.Links)+1]
+				if m.Links[len(m.Links)-1] == nil {
+					m.Links[len(m.Links)-1] = &SpanLink{}
+				}
+			}
 			if err := m.Links[len(m.Links)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1221,7 +1342,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.SelfTime == nil {
-				m.SelfTime = &AggregatedDuration{}
+				m.SelfTime = AggregatedDurationFromVTPool()
 			}
 			if err := m.SelfTime.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1646,7 +1767,7 @@ func (m *DestinationService) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.ResponseTime == nil {
-				m.ResponseTime = &AggregatedDuration{}
+				m.ResponseTime = AggregatedDurationFromVTPool()
 			}
 			if err := m.ResponseTime.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/trace_vtproto.pb.go
+++ b/model/modelpb/trace_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -94,6 +95,24 @@ func (m *Trace) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Trace = sync.Pool{
+	New: func() interface{} {
+		return &Trace{}
+	},
+}
+
+func (m *Trace) ResetVT() {
+	m.Reset()
+}
+func (m *Trace) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Trace.Put(m)
+	}
+}
+func TraceFromVTPool() *Trace {
+	return vtprotoPool_Trace.Get().(*Trace)
+}
 func (m *Trace) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/transaction_vtproto.pb.go
+++ b/model/modelpb/transaction_vtproto.pb.go
@@ -26,6 +26,7 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -505,6 +506,93 @@ func (m *DroppedSpanStats) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_Transaction = sync.Pool{
+	New: func() interface{} {
+		return &Transaction{}
+	},
+}
+
+func (m *Transaction) ResetVT() {
+	m.SpanCount.ReturnToVTPool()
+	m.UserExperience.ReturnToVTPool()
+	for _, mm := range m.Custom {
+		mm.ResetVT()
+	}
+	m.Message.ReturnToVTPool()
+	m.DurationHistogram.ReturnToVTPool()
+	for _, mm := range m.DroppedSpansStats {
+		mm.ResetVT()
+	}
+	m.DurationSummary.ReturnToVTPool()
+	m.Reset()
+}
+func (m *Transaction) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_Transaction.Put(m)
+	}
+}
+func TransactionFromVTPool() *Transaction {
+	return vtprotoPool_Transaction.Get().(*Transaction)
+}
+
+var vtprotoPool_SpanCount = sync.Pool{
+	New: func() interface{} {
+		return &SpanCount{}
+	},
+}
+
+func (m *SpanCount) ResetVT() {
+	m.Reset()
+}
+func (m *SpanCount) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_SpanCount.Put(m)
+	}
+}
+func SpanCountFromVTPool() *SpanCount {
+	return vtprotoPool_SpanCount.Get().(*SpanCount)
+}
+
+var vtprotoPool_TransactionMark = sync.Pool{
+	New: func() interface{} {
+		return &TransactionMark{}
+	},
+}
+
+func (m *TransactionMark) ResetVT() {
+	m.Reset()
+}
+func (m *TransactionMark) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_TransactionMark.Put(m)
+	}
+}
+func TransactionMarkFromVTPool() *TransactionMark {
+	return vtprotoPool_TransactionMark.Get().(*TransactionMark)
+}
+
+var vtprotoPool_DroppedSpanStats = sync.Pool{
+	New: func() interface{} {
+		return &DroppedSpanStats{}
+	},
+}
+
+func (m *DroppedSpanStats) ResetVT() {
+	m.Duration.ReturnToVTPool()
+	m.Reset()
+}
+func (m *DroppedSpanStats) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_DroppedSpanStats.Put(m)
+	}
+}
+func DroppedSpanStatsFromVTPool() *DroppedSpanStats {
+	return vtprotoPool_DroppedSpanStats.Get().(*DroppedSpanStats)
+}
 func (m *Transaction) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -708,7 +796,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.SpanCount == nil {
-				m.SpanCount = &SpanCount{}
+				m.SpanCount = SpanCountFromVTPool()
 			}
 			if err := m.SpanCount.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -744,7 +832,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.UserExperience == nil {
-				m.UserExperience = &UserExperience{}
+				m.UserExperience = UserExperienceFromVTPool()
 			}
 			if err := m.UserExperience.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -779,7 +867,14 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Custom = append(m.Custom, &KeyValue{})
+			if len(m.Custom) == cap(m.Custom) {
+				m.Custom = append(m.Custom, &KeyValue{})
+			} else {
+				m.Custom = m.Custom[:len(m.Custom)+1]
+				if m.Custom[len(m.Custom)-1] == nil {
+					m.Custom[len(m.Custom)-1] = &KeyValue{}
+				}
+			}
 			if err := m.Custom[len(m.Custom)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -943,7 +1038,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Message == nil {
-				m.Message = &Message{}
+				m.Message = MessageFromVTPool()
 			}
 			if err := m.Message.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1107,7 +1202,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.DurationHistogram == nil {
-				m.DurationHistogram = &Histogram{}
+				m.DurationHistogram = HistogramFromVTPool()
 			}
 			if err := m.DurationHistogram.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1142,7 +1237,14 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.DroppedSpansStats = append(m.DroppedSpansStats, &DroppedSpanStats{})
+			if len(m.DroppedSpansStats) == cap(m.DroppedSpansStats) {
+				m.DroppedSpansStats = append(m.DroppedSpansStats, &DroppedSpanStats{})
+			} else {
+				m.DroppedSpansStats = m.DroppedSpansStats[:len(m.DroppedSpansStats)+1]
+				if m.DroppedSpansStats[len(m.DroppedSpansStats)-1] == nil {
+					m.DroppedSpansStats[len(m.DroppedSpansStats)-1] = &DroppedSpanStats{}
+				}
+			}
 			if err := m.DroppedSpansStats[len(m.DroppedSpansStats)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1177,7 +1279,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.DurationSummary == nil {
-				m.DurationSummary = &SummaryMetric{}
+				m.DurationSummary = SummaryMetricFromVTPool()
 			}
 			if err := m.DurationSummary.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1691,7 +1793,7 @@ func (m *DroppedSpanStats) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Duration == nil {
-				m.Duration = &AggregatedDuration{}
+				m.Duration = AggregatedDurationFromVTPool()
 			}
 			if err := m.Duration.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/url_vtproto.pb.go
+++ b/model/modelpb/url_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -148,6 +149,24 @@ func (m *URL) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_URL = sync.Pool{
+	New: func() interface{} {
+		return &URL{}
+	},
+}
+
+func (m *URL) ResetVT() {
+	m.Reset()
+}
+func (m *URL) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_URL.Put(m)
+	}
+}
+func URLFromVTPool() *URL {
+	return vtprotoPool_URL.Get().(*URL)
+}
 func (m *URL) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/user_vtproto.pb.go
+++ b/model/modelpb/user_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -118,6 +119,24 @@ func (m *User) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_User = sync.Pool{
+	New: func() interface{} {
+		return &User{}
+	},
+}
+
+func (m *User) ResetVT() {
+	m.Reset()
+}
+func (m *User) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_User.Put(m)
+	}
+}
+func UserFromVTPool() *User {
+	return vtprotoPool_User.Get().(*User)
+}
 func (m *User) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/useragent_vtproto.pb.go
+++ b/model/modelpb/useragent_vtproto.pb.go
@@ -24,6 +24,7 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
+	sync "sync"
 
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -102,6 +103,24 @@ func (m *UserAgent) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+var vtprotoPool_UserAgent = sync.Pool{
+	New: func() interface{} {
+		return &UserAgent{}
+	},
+}
+
+func (m *UserAgent) ResetVT() {
+	m.Reset()
+}
+func (m *UserAgent) ReturnToVTPool() {
+	if m != nil {
+		m.ResetVT()
+		vtprotoPool_UserAgent.Put(m)
+	}
+}
+func UserAgentFromVTPool() *UserAgent {
+	return vtprotoPool_UserAgent.Get().(*UserAgent)
+}
 func (m *UserAgent) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/tools/generate-modelpb.sh
+++ b/tools/generate-modelpb.sh
@@ -9,6 +9,6 @@ PATH="${TOOLS_DIR}/build/bin:${PATH}" protoc \
     --go_out=. \
     --go_opt=module=github.com/elastic/apm-data \
     --go-vtproto_out=. \
-    --go-vtproto_opt=features=marshal+unmarshal+size+pool+clone,pool=./modelpb.APMEvent,module=github.com/elastic/apm-data \
+    --go-vtproto_opt=features=marshal+unmarshal+size+pool+clone,module=github.com/elastic/apm-data \
     ${PROTOC_VT_STRUCTS} \
     ./model/proto/*.proto

--- a/tools/generate-modelpb.sh
+++ b/tools/generate-modelpb.sh
@@ -2,4 +2,13 @@
 
 TOOLS_DIR=$(dirname "$(readlink -f -- "$0")")
 
-PATH="${TOOLS_DIR}/build/bin:${PATH}" protoc --proto_path=./model/proto/ --go_out=. --go_opt=module=github.com/elastic/apm-data --go-vtproto_out=. --go-vtproto_opt=features=marshal+unmarshal+size+pool+clone,module=github.com/elastic/apm-data ./model/proto/*.proto
+STRUCTS=$(grep '^message' ./model/proto/*.proto | cut -d ' ' -f2)
+PROTOC_VT_STRUCTS=$(for s in ${STRUCTS}; do echo --go-vtproto_opt=pool=github.com/elastic/apm-data/model/modelpb.$s ;done)
+PATH="${TOOLS_DIR}/build/bin:${PATH}" protoc \
+    --proto_path=./model/proto/ \
+    --go_out=. \
+    --go_opt=module=github.com/elastic/apm-data \
+    --go-vtproto_out=. \
+    --go-vtproto_opt=features=marshal+unmarshal+size+pool+clone,pool=./modelpb.APMEvent,module=github.com/elastic/apm-data \
+    ${PROTOC_VT_STRUCTS} \
+    ./model/proto/*.proto


### PR DESCRIPTION
Not sure if it was intended but to generate pool method we need to specify `--go-vtproto_opt=pool=<package>.<message_name>`. Before the PR, no pool methods were generated even though the `pool` feature was selected.