### PR TITLE
feat: strict http headers null validation with tests

### DIFF
--- a/input/elasticapm/internal/modeldecoder/nullable/nullable.go
+++ b/input/elasticapm/internal/modeldecoder/nullable/nullable.go
@@ -128,7 +128,6 @@ func init() {
 			h := http.Header{}
 			for key, val := range m {
 				switch v := val.(type) {
-				case nil:
 				case string:
 					h.Add(key, v)
 				case []interface{}:

--- a/input/elasticapm/internal/modeldecoder/nullable/nullable_test.go
+++ b/input/elasticapm/internal/modeldecoder/nullable/nullable_test.go
@@ -326,6 +326,8 @@ func TestHTTPHeader(t *testing.T) {
 			}},
 		{name: "valid2", input: `{"h":{"k":["a","b"]}}`, isSet: true, val: http.Header{"K": []string{"a", "b"}}},
 		{name: "null", input: `{"h":null}`},
+		{name: "null-value", input: `{"h":{"k": null}`, fail: true},
+		{name: "null-array", input: `{"h":{"k": [null]}`, fail: true},
 		{name: "invalid-type", input: `{"h":""}`, fail: true, isSet: true},
 		{name: "invalid-array", input: `{"h":{"k":["a",23]}}`, isSet: true, fail: true},
 		{name: "missing", input: `{}`},


### PR DESCRIPTION
Do not allow nill http headers value and add tests to verify the behaviour

Closes https://github.com/elastic/apm-data/issues/135