### PR TITLE
Add RemoveEventReceived processor

### DIFF
--- a/model/modelprocessor/eventreceived.go
+++ b/model/modelprocessor/eventreceived.go
@@ -1,0 +1,42 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor
+
+import (
+	"context"
+
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+// RemoveEventReceived is a processor that removes event.received
+// field as it should not be indexed.
+type RemoveEventReceived struct{}
+
+// ProcessBatch removes event.received field for events.
+func (RemoveEventReceived) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+	for i := range *b {
+		removeEventReceived((*b)[i])
+	}
+	return nil
+}
+
+func removeEventReceived(event *modelpb.APMEvent) {
+	if event.Event != nil {
+		event.Event.Received = 0
+	}
+}

--- a/model/modelprocessor/eventreceived_test.go
+++ b/model/modelprocessor/eventreceived_test.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor_test
+
+import (
+	"testing"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/apm-data/model/modelprocessor"
+)
+
+func TestRemoveEventReceived(t *testing.T) {
+	processor := modelprocessor.RemoveEventReceived{}
+
+	for _, tc := range []struct {
+		name     string
+		input    *modelpb.APMEvent
+		expected *modelpb.APMEvent
+	}{
+		{
+			name: "with event",
+			input: &modelpb.APMEvent{
+				Event: &modelpb.Event{
+					Received: 1000,
+				},
+			},
+			expected: &modelpb.APMEvent{
+				Event: &modelpb.Event{
+					Received: 0,
+				},
+			},
+		},
+		{
+			name:     "without event",
+			input:    &modelpb.APMEvent{},
+			expected: &modelpb.APMEvent{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testProcessBatch(t, processor, tc.input, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
Moves [removeEventReceivedBatchProcessor](https://github.com/elastic/apm-server/blob/8.9/internal/beater/processors.go#L89) from apm-server to apm-data. It is responsible for removing `event.received` from APMEvent so that the field is not indexed.