### PR TITLE
perf: pass error exception by pointer and avoid unnecessary string alloc

### DIFF
--- a/input/elasticapm/internal/modeldecoder/rumv3/decoder.go
+++ b/input/elasticapm/internal/modeldecoder/rumv3/decoder.go
@@ -228,7 +228,7 @@ func mapToErrorModel(from *errorEvent, event *modelpb.APMEvent) {
 	}
 	if from.Exception.IsSet() {
 		out.Exception = modelpb.ExceptionFromVTPool()
-		mapToExceptionModel(from.Exception, out.Exception)
+		mapToExceptionModel(&from.Exception, out.Exception)
 	}
 	if from.ID.IsSet() {
 		out.Id = from.ID.Val
@@ -283,7 +283,7 @@ func mapToErrorModel(from *errorEvent, event *modelpb.APMEvent) {
 	}
 }
 
-func mapToExceptionModel(from errorException, out *modelpb.Exception) {
+func mapToExceptionModel(from *errorException, out *modelpb.Exception) {
 	if len(from.Attributes) > 0 {
 		out.Attributes = modeldecoderutil.ToKv(from.Attributes, out.Attributes)
 	}
@@ -293,11 +293,12 @@ func mapToExceptionModel(from errorException, out *modelpb.Exception) {
 	if len(from.Cause) > 0 {
 		out.Cause = modeldecoderutil.Reslice(out.Cause, len(from.Cause), modelpb.ExceptionFromVTPool)
 		for i := 0; i < len(from.Cause); i++ {
-			mapToExceptionModel(from.Cause[i], out.Cause[i])
+			mapToExceptionModel(&from.Cause[i], out.Cause[i])
 		}
 	}
 	if from.Handled.IsSet() {
-		out.Handled = &from.Handled.Val
+		handled := from.Handled.Val
+		out.Handled = &handled
 	}
 	if from.Message.IsSet() {
 		out.Message = from.Message.Val

--- a/input/elasticapm/internal/modeldecoder/v2/decoder.go
+++ b/input/elasticapm/internal/modeldecoder/v2/decoder.go
@@ -457,7 +457,7 @@ func mapToErrorModel(from *errorEvent, event *modelpb.APMEvent) {
 	}
 	if from.Exception.IsSet() {
 		out.Exception = modelpb.ExceptionFromVTPool()
-		mapToExceptionModel(from.Exception, out.Exception)
+		mapToExceptionModel(&from.Exception, out.Exception)
 	}
 	if from.ID.IsSet() {
 		out.Id = from.ID.Val
@@ -513,7 +513,7 @@ func mapToErrorModel(from *errorEvent, event *modelpb.APMEvent) {
 	}
 }
 
-func mapToExceptionModel(from errorException, out *modelpb.Exception) {
+func mapToExceptionModel(from *errorException, out *modelpb.Exception) {
 	if len(from.Attributes) > 0 {
 		out.Attributes = modeldecoderutil.ToKv(from.Attributes, out.Attributes)
 	}
@@ -523,11 +523,12 @@ func mapToExceptionModel(from errorException, out *modelpb.Exception) {
 	if len(from.Cause) > 0 {
 		out.Cause = modeldecoderutil.Reslice(out.Cause, len(from.Cause), modelpb.ExceptionFromVTPool)
 		for i := 0; i < len(from.Cause); i++ {
-			mapToExceptionModel(from.Cause[i], out.Cause[i])
+			mapToExceptionModel(&from.Cause[i], out.Cause[i])
 		}
 	}
 	if from.Handled.IsSet() {
-		out.Handled = &from.Handled.Val
+		handled := from.Handled.Val
+		out.Handled = &handled
 	}
 	if from.Message.IsSet() {
 		out.Message = from.Message.Val


### PR DESCRIPTION
Benchstat output:

```
                            │   old.txt   │              new.txt               │
                            │   sec/op    │   sec/op     vs base               │
MapToModelPb/error-model-20   2.071µ ± 2%   1.926µ ± 1%  -7.00% (p=0.000 n=10)

                            │   old.txt   │              new.txt               │
                            │    B/op     │    B/op     vs base                │
MapToModelPb/error-model-20   1137.0 ± 0%   956.0 ± 0%  -15.92% (p=0.000 n=10)

                            │  old.txt   │              new.txt              │
                            │ allocs/op  │ allocs/op   vs base               │
MapToModelPb/error-model-20   29.00 ± 0%   27.00 ± 0%  -6.90% (p=0.000 n=10)
```

Benchmark was taken from https://github.com/elastic/apm-data/pull/152/files#diff-a5e37ae0c7575b86b499a4cf84b6bb1bbd18a528d1d1843df2564c2fd1e25f6aR575

