### PR TITLE
ci: enable bench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
 
   run-benchdiff:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      # for the GitHub comment with the outcome
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,26 +36,11 @@ jobs:
 
   run-benchdiff:
     runs-on: ubuntu-latest
-    permissions:
-      # for the GitHub comment with the outcome
-      pull-requests: write
+    permissions: write-all
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Notify with a GitHub comment and fail fast if no permissions
-      uses: actions/github-script@v6
-      with:
-        script: |
-          console.log(`Repo ${context.repo.repo}`)
-          console.log(`Issue ${context.issue.number}`)
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: "test"
-          })
-
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
@@ -106,3 +91,13 @@ jobs:
             repo: context.repo.repo,
             body: body
           })
+
+    - name: Notify benchdiff with a GitHub summary
+      continue-on-error: true
+      uses: actions/github-script@v6
+      with:
+        script: |
+          await core.summary
+            .addHeading('Benchdiff')
+            .addDetails('Results', '${{ steps.benchdiff.outputs.benchstat_output }}')
+            .write()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: ci
 on: ["push", "pull_request"]
 
-permissions:
-  contents: read
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -44,6 +41,19 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Notify with a GitHub comment and fail fast if no permissions
+      uses: actions/github-script@v6
+      with:
+        script: |
+          console.log(`Repo ${context.repo.repo}`)
+          console.log(`Issue ${context.issue.number}`)
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: "test"
+          })
+
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      statuses: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,25 @@ jobs:
       run: make bench
       env:
         BENCH_COUNT: 5
+
+  run-bench-report:
+    runs-on: ubuntu-latest
+    steps:
+    # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.3
+    - uses: WillAbides/benchdiff-action@4d1d267fa96763646dd7c0d58e242817ce392c61
+      with:
+        benchdiff_version: 0.9.1
+        status_sha: ${{ github.sha }}
+        status_name: benchdiff-result
+        status_on_degraded: neutral
+        # See https://github.com/WillAbides/benchdiff
+        benchdiff_args: |
+          --base-ref=origin/main
+          --cpu=1,2
+          --count=10
+          --warmup-count=1
+          --warmup-time=10ms
+          --benchtime=10ms
+          --tolerance=20
+          --benchmem
+          --debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,10 @@ jobs:
   run-bench:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-        cache: true
     - name: Run bench
       run: make bench
       env:
@@ -56,10 +55,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-        cache: true
     # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.3
     - uses: WillAbides/benchdiff-action@4d1d267fa96763646dd7c0d58e242817ce392c61
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,5 +99,15 @@ jobs:
         script: |
           await core.summary
             .addHeading('Benchdiff')
-            .addDetails('Results', '${{ steps.benchdiff.outputs.benchstat_output }}')
+            .addCodeBlock(`${{ steps.benchdiff.outputs.benchstat_output }}`)
+            .write()
+
+    - name: Notify benchdiff with a GitHub summary with raw
+      continue-on-error: true
+      uses: actions/github-script@v6
+      with:
+        script: |
+          await core.summary
+            .addHeading('Benchdiff')
+            .addRaw(`${{ steps.benchdiff.outputs.benchstat_output }}`)
             .write()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         go-version-file: go.mod
     # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.3
     - uses: WillAbides/benchdiff-action@4d1d267fa96763646dd7c0d58e242817ce392c61
+      id: benchdiff
+      continue-on-error: true
       with:
         benchdiff_version: 0.9.1
         status_sha: ${{ github.sha }}
@@ -65,3 +67,28 @@ jobs:
           --tolerance=20
           --benchmem
           --debug
+
+    - name: Notify benchdiff with a GitHub comment
+      continue-on-error: true
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const body = ```## Benchdiff
+          Command: `${{ steps.benchdiff.outputs.bench_command }}`
+          HEAD: ${{ steps.benchdiff.outputs.head_sha }}
+          Base: ${{ steps.benchdiff.outputs.base_sha }}
+          Degraded: ${{ steps.benchdiff.outputs.degraded_result }}
+
+          <details>
+          <summary>Results</summary>
+
+          ${{ steps.diff.outputs.benchstat_output }}
+
+          </details>
+          ```.replace(/  +/g, '')
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      statuses: write
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,10 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-          const body = ```## Benchdiff
-          Issue: `${context.issue.number}`
-          Repo: `${context.repo.repo}`
-          Command: `${{ steps.benchdiff.outputs.bench_command }}`
+          console.log(`Repo ${context.repo.repo}`)
+          console.log(`Issue ${context.issue.number}`)
+          const body = `## Benchdiff
+          Command: \`${{ steps.benchdiff.outputs.bench_command }}\`
           HEAD: ${{ steps.benchdiff.outputs.head_sha }}
           Base: ${{ steps.benchdiff.outputs.base_sha }}
           Degraded: ${{ steps.benchdiff.outputs.degraded_result }}
@@ -87,7 +87,7 @@ jobs:
           ${{ steps.benchdiff.outputs.benchstat_output }}
 
           </details>
-          ```.replace(/  +/g, '')
+          `.replace(/  +/g, '')
           github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
       with:
         script: |
           const body = ```## Benchdiff
+          Issue: `${context.issue.number}`
+          Repo: `${context.repo.repo}`
           Command: `${{ steps.benchdiff.outputs.bench_command }}`
           HEAD: ${{ steps.benchdiff.outputs.head_sha }}
           Base: ${{ steps.benchdiff.outputs.base_sha }}
@@ -82,7 +84,7 @@ jobs:
           <details>
           <summary>Results</summary>
 
-          ${{ steps.diff.outputs.benchstat_output }}
+          ${{ steps.benchdiff.outputs.benchstat_output }}
 
           </details>
           ```.replace(/  +/g, '')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: actions/setup-go@v3
       with:
         go-version-file: go.mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,16 @@ jobs:
         cache: true
     - name: Run tests
       run: make test
+
+  run-bench:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+        cache: true
+    - name: Run bench
+      run: make bench
+      env:
+        BENCH_COUNT: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
 
   run-bench-report:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,7 @@ jobs:
 
   run-benchdiff:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: write
+    permissions: write-all
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
   run-bench-report:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+        cache: true
     # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.3
     - uses: WillAbides/benchdiff-action@4d1d267fa96763646dd7c0d58e242817ce392c61
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,19 +37,7 @@ jobs:
     - name: Run tests
       run: make test
 
-  run-bench:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
-      with:
-        go-version-file: go.mod
-    - name: Run bench
-      run: make bench
-      env:
-        BENCH_COUNT: 5
-
-  run-bench-report:
+  run-benchdiff:
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -71,10 +59,10 @@ jobs:
         benchdiff_args: |
           --base-ref=origin/main
           --cpu=1,2
-          --count=10
+          --count=5
           --warmup-count=1
           --warmup-time=10ms
-          --benchtime=10ms
+          --benchtime=100ms
           --tolerance=20
           --benchmem
           --debug

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,6 @@ all: generate-modelpb generate gomodtidy update-licenses fieldalignment fmt prot
 test:
 	go test -v -race ./...
 
-BENCH_BENCHTIME?=100ms
-BENCH_COUNT?=1
-.PHONY: bench
-bench:
-	go test -count=$(BENCH_COUNT) -benchmem -run=XXX -benchtime=$(BENCH_BENCHTIME) -bench='.*' ./...
-
 fmt:
 	go run golang.org/x/tools/cmd/goimports@v0.3.0 -w .
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ all: generate-modelpb generate gomodtidy update-licenses fieldalignment fmt prot
 test:
 	go test -v -race ./...
 
+BENCH_BENCHTIME?=100ms
+BENCH_COUNT?=1
+.PHONY: bench
+bench:
+	go test -count=$(BENCH_COUNT) -benchmem -run=XXX -benchtime=$(BENCH_BENCHTIME) -bench='.*' ./...
+
 fmt:
 	go run golang.org/x/tools/cmd/goimports@v0.3.0 -w .
 


### PR DESCRIPTION
### What

similarly done in https://github.com/elastic/apm-server/blob/a9d814c9bd2664956bb09ac6269d29c91c64bb06/Makefile\#L121C1-L125C102

### Issue

part of https://github.com/elastic/apm-data/issues/97


### Tasks

- Visualise the benchmarks somehow. Maybe https://github.com/elastic/apm-pipeline-library/pull/1748 but as a GitHub check annotation instead?