### PR TITLE
action(benchdiff): avoid failing on forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,21 @@ jobs:
     - name: Summary
       run: |
         echo "${{ steps.benchdiff.outputs.benchstat_output }}" > benchdiff-report.md
-        echo "${{ steps.benchdiff.outputs.benchstat_output }}" >> $GITHUB_STEP_SUMMARY
+        {
+          echo "## Benchdiff Results"
+          echo ""
+          echo "Command: `${{ steps.benchdiff.outputs.bench_command }}`"
+          echo "HEAD: ${{ steps.benchdiff.outputs.head_sha }}"
+          echo "Base: ${{ steps.benchdiff.outputs.base_sha }}"
+          echo "Degraded: ${{ steps.benchdiff.outputs.degraded_result }}"
+          echo ""
+          echo "<details>"
+          echo "<summary>Results</summary>"
+          echo ""
+          echo "${{ steps.benchdiff.outputs.benchstat_output }}"
+          echo ""
+          echo "</details>"
+        } >> $GITHUB_STEP_SUMMARY
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         {
           echo "## Benchdiff Results"
           echo ""
-          echo "Command: `${{ steps.benchdiff.outputs.bench_command }}`"
           echo "HEAD: ${{ steps.benchdiff.outputs.head_sha }}"
           echo "Base: ${{ steps.benchdiff.outputs.base_sha }}"
           echo "Degraded: ${{ steps.benchdiff.outputs.degraded_result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
         go-version-file: go.mod
     # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.3
     - uses: WillAbides/benchdiff-action@4d1d267fa96763646dd7c0d58e242817ce392c61
+      ## As long as we cannot use write permissions on forked pull requests, then let's avoid failing
+      continue-on-error: true
       id: benchdiff
       with:
         benchdiff_version: 0.9.1
@@ -67,3 +69,10 @@ jobs:
           --tolerance=20
           --benchmem
           --debug
+
+    - run: echo "${{ steps.benchdiff.outputs.benchstat_output }}" > benchdiff-report.md
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: benchdiff-report
+        path: benchdiff-report.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,10 @@ jobs:
           --benchmem
           --debug
 
-    - run: echo "${{ steps.benchdiff.outputs.benchstat_output }}" > benchdiff-report.md
+    - name: Summary
+      run: |
+        echo "${{ steps.benchdiff.outputs.benchstat_output }}" > benchdiff-report.md
+        echo "${{ steps.benchdiff.outputs.benchstat_output }}" >> $GITHUB_STEP_SUMMARY
 
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Store benchdiff-report

Permissions are not allowed when using `pull_request` for forked PRs. But we cannot use `pull_request_target`.

For the time being, we will not fail for forked PRs but archive the report in the workflow and create the GitHub summary report in the gitHub workflow.

See https://github.com/elastic/apm-data/actions/runs/6561394516?pr=173#summary-17820987548