### PR TITLE
fix: gracefully handle empty request body

### DIFF
--- a/input/elasticapm/processor_test.go
+++ b/input/elasticapm/processor_test.go
@@ -170,6 +170,8 @@ func TestHandleStreamErrors(t *testing.T) {
 			},
 		},
 	}, {
+		name: "EmptyEvent",
+	}, {
 		name:     "TooLargeEvent",
 		payload:  validMetadata + "\n" + tooLargeEvent + "\n",
 		tooLarge: 1,


### PR DESCRIPTION
Sending an empty request to APM Server results in the following error:

```
{"errors":[{"message":"EOF while reading metadata"}],"accepted":0}
```

Looking at recent requests in the grouped error dashboard:

94% of the requests are sent to `/intake/v2/events?flushed=true`
5% of requests are sent to `/intake/v2/rum/events`

This PR handle empty request gracefully by returning an empty result.