### PR TITLE
Require only one of exception.{type,message} for log exceptions

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -180,11 +180,9 @@ func (c *Consumer) convertLogRecord(
 		return true
 	})
 
-	if exceptionMessage != "" && exceptionType != "" {
-		// Per OpenTelemetry semantic conventions:
-		//   `At least one of the following sets of attributes is required:
-		//   - exception.type
-		//   - exception.message`
+	// NOTE: we consider an error anything that contains an exception type
+	// or message, indipendently from the severity level.
+	if exceptionMessage != "" || exceptionType != "" {
 		event.Error = convertOpenTelemetryExceptionSpanEvent(
 			exceptionType, exceptionMessage, exceptionStacktrace,
 			exceptionEscaped, event.Service.Language.Name,


### PR DESCRIPTION

Change OTLP log input to identify as exception any log that has an exception message or type attribute.

Before this change only logs with both attributes where considered as exceptions.

Closes https://github.com/elastic/apm-data/issues/176
