### PR TITLE
feat: map OTEL's `span.status: Unset` to `event.outcome: success`

### DIFF
--- a/input/elasticapm/internal/modeldecoder/v2/span_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/span_test.go
@@ -172,17 +172,18 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		input.Context.HTTP.StatusCode.Set(http.StatusBadRequest)
 		mapToSpanModel(&input, &out)
 		assert.Equal(t, "failure", out.Event.Outcome)
-		// derive from other fields - success
-		input.Outcome.Reset()
-		input.Context.HTTP.StatusCode.Reset()
-		mapToSpanModel(&input, &out)
-		assert.Equal(t, "success", out.Event.Outcome)
-		// derive from other fields - unknown when not otel
+		// derive from other fields - unknown
 		input.Outcome.Reset()
 		input.OTel.Reset()
 		input.Context.HTTP.StatusCode.Reset()
 		mapToSpanModel(&input, &out)
 		assert.Equal(t, "unknown", out.Event.Outcome)
+		// outcome is success when not assigned and it's otel
+		input.Outcome.Reset()
+		input.OTel.SpanKind.Set(spanKindInternal)
+		input.Context.HTTP.StatusCode.Reset()
+		mapToSpanModel(&input, &out)
+		assert.Equal(t, "success", out.Event.Outcome)
 	})
 
 	t.Run("timestamp", func(t *testing.T) {

--- a/input/elasticapm/internal/modeldecoder/v2/span_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/span_test.go
@@ -172,8 +172,14 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		input.Context.HTTP.StatusCode.Set(http.StatusBadRequest)
 		mapToSpanModel(&input, &out)
 		assert.Equal(t, "failure", out.Event.Outcome)
-		// derive from other fields - unknown
+		// derive from other fields - success
 		input.Outcome.Reset()
+		input.Context.HTTP.StatusCode.Reset()
+		mapToSpanModel(&input, &out)
+		assert.Equal(t, "success", out.Event.Outcome)
+		// derive from other fields - unknown when not otel
+		input.Outcome.Reset()
+		input.OTel.Reset()
 		input.Context.HTTP.StatusCode.Reset()
 		mapToSpanModel(&input, &out)
 		assert.Equal(t, "unknown", out.Event.Outcome)

--- a/input/elasticapm/internal/modeldecoder/v2/transaction_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/transaction_test.go
@@ -421,8 +421,15 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		input.Context.Response.StatusCode.Set(http.StatusInternalServerError)
 		mapToTransactionModel(&input, &out)
 		assert.Equal(t, "failure", out.Event.Outcome)
+		// derive from other fields - if unset, treat it as success
+		input.Outcome.Reset()
+		input.Context.Response.StatusCode.Reset()
+		mapToTransactionModel(&input, &out)
+		assert.Equal(t, "success", out.Event.Outcome)
+
 		// derive from other fields - unknown
 		input.Outcome.Reset()
+		input.OTel.Reset()
 		input.Context.Response.StatusCode.Reset()
 		mapToTransactionModel(&input, &out)
 		assert.Equal(t, "unknown", out.Event.Outcome)

--- a/input/elasticapm/internal/modeldecoder/v2/transaction_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/transaction_test.go
@@ -421,18 +421,18 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		input.Context.Response.StatusCode.Set(http.StatusInternalServerError)
 		mapToTransactionModel(&input, &out)
 		assert.Equal(t, "failure", out.Event.Outcome)
-		// derive from other fields - if unset, treat it as success
-		input.Outcome.Reset()
-		input.Context.Response.StatusCode.Reset()
-		mapToTransactionModel(&input, &out)
-		assert.Equal(t, "success", out.Event.Outcome)
-
 		// derive from other fields - unknown
 		input.Outcome.Reset()
 		input.OTel.Reset()
 		input.Context.Response.StatusCode.Reset()
 		mapToTransactionModel(&input, &out)
 		assert.Equal(t, "unknown", out.Event.Outcome)
+		// outcome is success when not assigned and it's otel
+		input.Outcome.Reset()
+		input.OTel.SpanKind.Set(spanKindInternal)
+		input.Context.Response.StatusCode.Reset()
+		mapToTransactionModel(&input, &out)
+		assert.Equal(t, "success", out.Event.Outcome)
 	})
 
 	t.Run("session", func(t *testing.T) {

--- a/input/otlp/test_approved/jaeger_sampling_rate.approved.json
+++ b/input/otlp/test_approved/jaeger_sampling_rate.approved.json
@@ -8,7 +8,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"
@@ -24,6 +24,7 @@
             },
             "transaction": {
                 "representative_count": 1.25,
+                "result": "Success",
                 "sampled": true,
                 "type": "unknown"
             }
@@ -36,7 +37,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"
@@ -69,7 +70,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"
@@ -91,6 +92,7 @@
             },
             "transaction": {
                 "sampled": true,
+                "result": "Success",
                 "type": "unknown"
             }
         },
@@ -102,7 +104,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"

--- a/input/otlp/test_approved/metadata_jaeger-no-language.approved.json
+++ b/input/otlp/test_approved/metadata_jaeger-no-language.approved.json
@@ -7,7 +7,7 @@
                 "version": "3.4.12"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "service": {
                 "language": {
@@ -28,6 +28,7 @@
                 "id": "0000000041414646",
                 "representative_count": 1,
                 "sampled": true,
+                "result": "Success",
                 "type": "unknown"
             }
         }

--- a/input/otlp/test_approved/metadata_jaeger-version.approved.json
+++ b/input/otlp/test_approved/metadata_jaeger-version.approved.json
@@ -7,7 +7,7 @@
                 "version": "3.4.12"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "service": {
                 "language": {
@@ -28,6 +28,7 @@
                 "id": "0000000041414646",
                 "representative_count": 1,
                 "sampled": true,
+                "result": "Success",
                 "type": "unknown"
             }
         }

--- a/input/otlp/test_approved/metadata_jaeger.approved.json
+++ b/input/otlp/test_approved/metadata_jaeger.approved.json
@@ -8,7 +8,7 @@
                 "version": "3.2.1"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-foo",
@@ -39,6 +39,7 @@
                 "id": "0000000041414646",
                 "representative_count": 1,
                 "sampled": true,
+                "result": "Success",
                 "type": "unknown"
             }
         }

--- a/input/otlp/test_approved/span_jaeger_custom.approved.json
+++ b/input/otlp/test_approved/span_jaeger_custom.approved.json
@@ -8,7 +8,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"

--- a/input/otlp/test_approved/span_jaeger_db.approved.json
+++ b/input/otlp/test_approved/span_jaeger_db.approved.json
@@ -12,7 +12,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"

--- a/input/otlp/test_approved/span_jaeger_https_default_port.approved.json
+++ b/input/otlp/test_approved/span_jaeger_https_default_port.approved.json
@@ -12,7 +12,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"

--- a/input/otlp/test_approved/span_jaeger_messaging.approved.json
+++ b/input/otlp/test_approved/span_jaeger_messaging.approved.json
@@ -12,7 +12,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"

--- a/input/otlp/test_approved/span_jaeger_subtype_component.approved.json
+++ b/input/otlp/test_approved/span_jaeger_subtype_component.approved.json
@@ -8,7 +8,7 @@
             },
             "event": {
                 "duration": 79000000000,
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"

--- a/input/otlp/test_approved/transaction_jaeger_custom.approved.json
+++ b/input/otlp/test_approved/transaction_jaeger_custom.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"
@@ -27,6 +27,7 @@
             "transaction": {
                 "representative_count": 1,
                 "sampled": true,
+                "result": "Success",
                 "type": "unknown"
             }
         }

--- a/input/otlp/test_approved/transaction_jaeger_type_component.approved.json
+++ b/input/otlp/test_approved/transaction_jaeger_type_component.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"
@@ -27,6 +27,7 @@
             "transaction": {
                 "representative_count": 1,
                 "sampled": true,
+                "result": "Success",
                 "type": "unknown"
             }
         }

--- a/input/otlp/test_approved/transaction_jaeger_type_messaging.approved.json
+++ b/input/otlp/test_approved/transaction_jaeger_type_messaging.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc"
@@ -31,6 +31,7 @@
                     }
                 },
                 "representative_count": 1,
+                "result": "Success",
                 "sampled": true,
                 "type": "messaging"
             }

--- a/input/otlp/traces_test.go
+++ b/input/otlp/traces_test.go
@@ -106,7 +106,7 @@ func TestOutcome(t *testing.T) {
 		assert.Equal(t, expectedOutcome, (*batch)[1].GetEvent().GetOutcome())
 	}
 
-	test(t, "unknown", "", ptrace.StatusCodeUnset)
+	test(t, "success", "Success", ptrace.StatusCodeUnset)
 	test(t, "success", "Success", ptrace.StatusCodeOk)
 	test(t, "failure", "Error", ptrace.StatusCodeError)
 }


### PR DESCRIPTION
apm-data translates `Span.status: Unset` as `event.outcome: unknown`. For OTEL, Unset status implies has not been failed/errored. We'd like to map Unset to success so we can calculate the correct [transaction failed rate](https://github.com/elastic/apm/blob/7ef63617e84081139e6b79b5006c035057dc42fb/specs/agents/tracing-transactions.md?plain=1#L40).

The [OTel specification](https://opentelemetry.io/docs/concepts/signals/traces/#span-status) writes the following on the SpanStatus being Unset:

> When an exception is handled, a Span status can be set to Error. Otherwise, a Span status is in the Unset state. By setting a Span status to Unset, the back-end that processes spans can now assign a final status.

So it should be ok for us map the Unset to success when we process the data.