### PR TITLE
remove async arg

### DIFF
--- a/input/elasticapm/processor.go
+++ b/input/elasticapm/processor.go
@@ -86,7 +86,6 @@ type Config struct {
 type StreamHandler interface {
 	HandleStream(
 		ctx context.Context,
-		async bool,
 		baseEvent *modelpb.APMEvent,
 		stream io.Reader,
 		batchSize int,


### PR DESCRIPTION
Follow-up of #193 , the `async` parameter was removed, but the `HandleStream` interface was not updated to reflect this.

This currently prevents updating apm-data version used in apm-server.

Once this is merged https://github.com/elastic/apm-server/pull/12386 will be unblocked and must have its version of apm-data updated.