### PR TITLE
Detect messaging.{system,operation} in TranslateTransaction

### DIFF
--- a/input/elasticapm/internal/modeldecoder/v2/transaction_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/transaction_test.go
@@ -561,6 +561,24 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 			}, event.Transaction.Message)
 		})
 
+		t.Run("messaging_without_destination", func(t *testing.T) {
+			var input transaction
+			var event modelpb.APMEvent
+			modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
+			input.Type.Reset()
+			attrs := map[string]interface{}{
+				"messaging.system":    "kafka",
+				"messaging.operation": "publish",
+			}
+			input.OTel.Attributes = attrs
+			input.OTel.SpanKind.Reset()
+
+			mapToTransactionModel(&input, &event)
+			assert.Equal(t, "messaging", event.Transaction.Type)
+			assert.Equal(t, "CONSUMER", event.Span.Kind)
+			assert.Nil(t, event.Transaction.Message)
+		})
+
 		t.Run("network", func(t *testing.T) {
 			attrs := map[string]interface{}{
 				"network.connection.type":    "cell",

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -252,6 +252,7 @@ func TranslateTransaction(
 	)
 
 	var isHTTP, isRPC, isMessaging bool
+	var messagingQueueName string
 
 	var samplerType, samplerParam pcommon.Value
 	attributes.Range(func(kDots string, v pcommon.Value) bool {
@@ -410,11 +411,8 @@ func TranslateTransaction(
 
 			// messaging.*
 			case "message_bus.destination", semconv.AttributeMessagingDestination:
-				if event.Transaction.Message == nil {
-					event.Transaction.Message = modelpb.MessageFromVTPool()
-				}
-				event.Transaction.Message.QueueName = stringval
 				isMessaging = true
+				messagingQueueName = stringval
 			case semconv.AttributeMessagingSystem:
 				isMessaging = true
 				modelpb.Labels(event.Labels).Set(k, stringval)
@@ -501,6 +499,14 @@ func TranslateTransaction(
 			}
 		}
 		event.Url = modelpb.ParseURL(httpURL, httpHost, httpScheme)
+	}
+	if isMessaging {
+		// Overwrite existing event.Transaction.Message
+		event.Transaction.Message = nil
+		if messagingQueueName != "" {
+			event.Transaction.Message = modelpb.MessageFromVTPool()
+			event.Transaction.Message.QueueName = messagingQueueName
+		}
 	}
 
 	if event.Client == nil && event.Source != nil {


### PR DESCRIPTION
Use `messaging.system` and `messaging.operation` to detect OTel messaging span in TranslateTransaction. The corresponding handling already exists in TranslateSpan.