### PR TITLE
action: use parenthesis and the correct sha

### DIFF
--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -13,7 +13,8 @@ jobs:
     # Support for branches, non-forked-prs or forked-prs with a label
     if: |
       contains(github.event.pull_request.labels.*.name, 'safe-to-test') ||
-      github.event_name != 'pull_request' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+      github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     permissions:
       checks: write
     steps:

--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -18,6 +18,11 @@ jobs:
     permissions:
       checks: write
     steps:
+    - name: Debug event types
+      run: |
+        echo "${{ github.event_name != 'pull_request' && github.sha || github.event.pull_request.head.sha }}"
+        echo "github.sha=${{ github.sha }}"
+        echo "github.event.pull_request.head.sha=${{ github.event.pull_request.head.sha }}"
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0

--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -30,7 +30,7 @@ jobs:
       id: benchdiff
       with:
         benchdiff_version: 0.9.1
-        status_sha: ${{ github.sha }}
+        status_sha: ${{ github.event_name != 'pull_request' && github.sha || github.event.pull_request.head.sha }}
         status_name: benchdiff-result
         status_on_degraded: neutral
         # See https://github.com/WillAbides/benchdiff

--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
+        ref: ${{ github.event_name != 'pull_request' && github.sha || github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod


### PR DESCRIPTION
Since it uses different on events, then it's required to set what's the sha commit to be used.

