### PR TITLE
github-action: tag safe-to-test for Pull Requests belonging to Elastic employees

### DIFF
--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -2,7 +2,7 @@ name: bench-diff
 on:
   push:
   pull_request_target:
-    types: [labeled]
+    types: [labeled, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/label-elastic-pull-requests.yml
+++ b/.github/workflows/label-elastic-pull-requests.yml
@@ -1,0 +1,28 @@
+name: "label-elastic-pull-requests"
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check team membership for user
+      uses: elastic/get-user-teams-membership@1.1.0
+      id: checkUserMember
+      with:
+        username: ${{ github.actor }}
+        team: 'apm'
+        GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+    - name: Add safe-to-test label
+      uses: actions/github-script@v7
+      if: steps.checkUserMember.outputs.isTeamMember == 'true'
+      with:
+        script: |
+          github.rest.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ["safe-to-test"]
+          })


### PR DESCRIPTION
I used a similar approach to https://github.com/elastic/apm-agent-java/blob/main/.github/workflows/labeler.yml

I changed the `on` condition to listen for the `synchronize` event:

> A pull request's head branch was updated. For example, the head branch was updated from the base branch or new commits were pushed to the head branch.

In https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request