### PR TITLE
github-action: pull_request_target event condition

### DIFF
--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -22,7 +22,7 @@ jobs:
       id: event
       run: |
         echo "DEBUG: event type(${{ github.event_name }})"
-        if [ "${{ github.event_name != 'pull_request' }}" = "true" ] ; then
+        if [ "${{ github.event_name != 'pull_request_target' }}" = "true" ] ; then
           echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
         else
           echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
I got confused with the event-name versus the event object.

This should help with using the right sha commit rather than the sha commit from the main.