### PR TITLE
github-action(label): use PAT instead of github-bot

### DIFF
--- a/.github/workflows/label-elastic-pull-requests.yml
+++ b/.github/workflows/label-elastic-pull-requests.yml
@@ -5,7 +5,7 @@ on:
     types: [opened]
 
 jobs:
-  triage:
+  safe-to-test:
     runs-on: ubuntu-latest
     steps:
     - name: Check team membership for user
@@ -19,6 +19,7 @@ jobs:
       uses: actions/github-script@v7
       if: steps.checkUserMember.outputs.isTeamMember == 'true'
       with:
+        github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
         script: |
           github.rest.issues.addLabels({
             issue_number: context.issue.number,


### PR DESCRIPTION
GitHub does not send any events if the actor is `github-bot`

I assume the existing PAT has the right permissions to attach labels.