### PR TITLE
github-action: support pull_request_target and pull_request events

### DIFF
--- a/.github/workflows/bench-diff.yml
+++ b/.github/workflows/bench-diff.yml
@@ -13,8 +13,8 @@ jobs:
     # Support for branches, non-forked-prs or forked-prs with a label
     if: |
       contains(github.event.pull_request.labels.*.name, 'safe-to-test') ||
-      github.event_name != 'pull_request' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+      ! startsWith(github.event_name, 'pull_request') ||
+      (startsWith(github.event_name, 'pull_request') && github.event.pull_request.head.repo.fork == false)
     permissions:
       checks: write
     steps:
@@ -22,11 +22,11 @@ jobs:
       id: event
       run: |
         echo "DEBUG: event type(${{ github.event_name }})"
-        if [ "${{ github.event_name != 'pull_request_target' }}" = "true" ] ; then
-          echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-        else
+        ref="${{ github.sha }}"
+        if [ "${{ startsWith(github.event_name, 'pull_request') }}" = "true" ] ; then
           echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
         fi
+        echo "ref=${ref}" >> "$GITHUB_OUTPUT"
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-    # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.3
+    # Version: https://github.com/WillAbides/benchdiff-action/releases/tag/v0.3.5
     - uses: WillAbides/benchdiff-action@990b4c50b5420b485bf87e42c9f18234eba76fbc
       id: benchdiff
       with:


### PR DESCRIPTION
`github.event_name != 'pull_request'` will be always true since it listens for `pull_request_target` events.

Let's use the startswith condition for `pull_request`.