### PR TITLE
feat: replace renovate with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,24 @@
 version: 2
 updates:
-
+  # Go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      otel:
+        patterns:
+        - "go.opentelemetry.io/*"
+      jaeger:
+        patterns:
+        - "github.com/jaegertracing/jaeger"
+        - "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+      golang.org/x/:
+        patterns:
+        - "golang.org/x/*"
+      go-agent:
+        patterns:
+        - "go.elastic.co/apm*"
   # GitHub actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
-  "automerge": true,
-  "automergeStrategy": "squash",
-  "gomodTidy": true
-}


### PR DESCRIPTION
Aligned with apm-server. Groups are mostly the same.

This won't cause a PR in downstream users unless we release a new version of the library