### PR TITLE
perf: do not pool on each iteration when processing the same batch

### DIFF
--- a/input/elasticapm/processor.go
+++ b/input/elasticapm/processor.go
@@ -319,13 +319,12 @@ func (p *Processor) handleStream(
 	return readErr
 }
 
-// processBatch processes the batch and returns it to the pool after it's been processed.
+// processBatch processes the batch and returns the events to the pool after it's been processed.
 func (p *Processor) processBatch(ctx context.Context, processor modelpb.BatchProcessor, batch *modelpb.Batch) error {
 	defer func() {
 		for i := range *batch {
 			(*batch)[i].ReturnToVTPool()
 		}
-		batchPool.Put(batch)
 	}()
 	return processor.ProcessBatch(ctx, batch)
 }


### PR DESCRIPTION
The processor is reading batchSize items at a time but on each iteration it retrieves and submit a batch to the pool. Now that we don't have the async code handling anymore we can just reuse the batch and only submit it to the pool once we're done reading the events.