### PR TITLE
fix otlp database span resource

### DIFF
--- a/input/otlp/test_approved/span_jaeger_db.approved.json
+++ b/input/otlp/test_approved/span_jaeger_db.approved.json
@@ -45,7 +45,7 @@
                 "destination": {
                     "service": {
                         "name": "sql",
-                        "resource": "mysql://db:3306",
+                        "resource": "mysql/db01",
                         "type": "db"
                     }
                 },

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -912,14 +912,15 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 		if event.Span.Subtype != "" {
 			serviceTarget.Type = event.Span.Subtype
 			if destinationService.Name == "" {
-				// For database requests, we currently just identify
-				// the destination service by db.system.
 				destinationService.Name = event.Span.Subtype
 				destinationService.Resource = event.Span.Subtype
 			}
 		}
 		if db.Instance != "" {
 			serviceTarget.Name = db.Instance
+			if destinationService.Resource != "" {
+				destinationService.Resource += "/" + db.Instance
+			}
 		}
 	case isMessaging:
 		event.Span.Type = "messaging"

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -918,9 +918,7 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 		}
 		if db.Instance != "" {
 			serviceTarget.Name = db.Instance
-			if destinationService.Resource != "" {
-				destinationService.Resource += "/" + db.Instance
-			}
+			destinationService.Resource = serviceTarget.Type + "/" + db.Instance
 		}
 	case isMessaging:
 		event.Span.Type = "messaging"

--- a/input/otlp/traces_test.go
+++ b/input/otlp/traces_test.go
@@ -527,7 +527,7 @@ func TestDatabaseSpan(t *testing.T) {
 	assert.Empty(t, cmp.Diff(&modelpb.DestinationService{
 		Type:     "db",
 		Name:     "mysql",
-		Resource: "mysql",
+		Resource: "mysql/ShopDb",
 	}, event.Span.DestinationService, protocmp.Transform()))
 }
 


### PR DESCRIPTION
With OTLP intake, the database spans always have their `span.destination.service.resource` set to `{span.subtype}`.

However when using our APM agents it's captured and sent as `{span.subtype}/{db.name}`, for example `mysql/my-database`.

This PR simply fixes the mapping for database spans.

Reported [in our forum here](https://discuss.elastic.co/t/how-to-define-span-destination-service-resource-witn-opentelemetry-integration/353305/3).