### PR TITLE
Add support for providing host.id via intakeV2.

### DIFF
--- a/input/elasticapm/docs/spec/v2/metadata.json
+++ b/input/elasticapm/docs/spec/v2/metadata.json
@@ -441,6 +441,14 @@
           ],
           "maxLength": 1024
         },
+        "host_id": {
+          "description": "The OpenTelemetry semantic conventions compliant \"host.id\" attribute, if available.",
+          "type": [
+            "null",
+            "string"
+          ],
+          "maxLength": 1024
+        },
         "hostname": {
           "description": "Deprecated: Use ConfiguredHostname and DetectedHostname instead. DeprecatedHostname is the host name of the system the service is running on. It does not distinguish between configured and detected hostname and therefore is deprecated and only used if no other hostname information is available.",
           "type": [

--- a/input/elasticapm/internal/modeldecoder/v2/decoder.go
+++ b/input/elasticapm/internal/modeldecoder/v2/decoder.go
@@ -715,6 +715,12 @@ func mapToMetadataModel(from *metadata, out *modelpb.APMEvent) {
 		}
 		out.Host.Hostname = from.System.DetectedHostname.Val
 	}
+	if from.System.HostId.IsSet() {
+		if out.Host == nil {
+			out.Host = modelpb.HostFromVTPool()
+		}
+		out.Host.Id = from.System.HostId.Val
+	}
 	if !from.System.ConfiguredHostname.IsSet() && !from.System.DetectedHostname.IsSet() &&
 		from.System.DeprecatedHostname.IsSet() {
 		if out.Host == nil {

--- a/input/elasticapm/internal/modeldecoder/v2/metadata_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/metadata_test.go
@@ -319,9 +319,11 @@ func TestDecodeMapToMetadataModel(t *testing.T) {
 		input.System.ConfiguredHostname.Set("configured-host")
 		input.System.DetectedHostname.Set("detected-host")
 		input.System.DeprecatedHostname.Set("deprecated-host")
+		input.System.HostId.Set("host-id")
 		mapToMetadataModel(&input, &out)
 		assert.Equal(t, "configured-host", out.Host.Name)
 		assert.Equal(t, "detected-host", out.Host.Hostname)
+		assert.Equal(t, "host-id", out.Host.Id)
 		// no detected-host information
 		out = modelpb.APMEvent{}
 		input.System.DetectedHostname.Reset()

--- a/input/elasticapm/internal/modeldecoder/v2/model.go
+++ b/input/elasticapm/internal/modeldecoder/v2/model.go
@@ -594,6 +594,8 @@ type metadataSystem struct {
 	Kubernetes metadataSystemKubernetes `json:"kubernetes"`
 	// Platform name of the system platform the monitored service is running on.
 	Platform nullable.String `json:"platform" validate:"maxLength=1024"`
+	// The OpenTelemetry semantic conventions compliant "host.id" attribute, if available.
+	HostId nullable.String `json:"host_id" validate:"maxLength=1024"`
 }
 
 type metadataSystemContainer struct {

--- a/input/elasticapm/internal/modeldecoder/v2/model_generated.go
+++ b/input/elasticapm/internal/modeldecoder/v2/model_generated.go
@@ -554,7 +554,7 @@ func (val *metadataCloudService) processNestedSource() error {
 }
 
 func (val *metadataSystem) IsSet() bool {
-	return val.Architecture.IsSet() || val.ConfiguredHostname.IsSet() || val.Container.IsSet() || val.DetectedHostname.IsSet() || val.DeprecatedHostname.IsSet() || val.Kubernetes.IsSet() || val.Platform.IsSet()
+	return val.Architecture.IsSet() || val.ConfiguredHostname.IsSet() || val.Container.IsSet() || val.DetectedHostname.IsSet() || val.DeprecatedHostname.IsSet() || val.Kubernetes.IsSet() || val.Platform.IsSet() || val.HostId.IsSet()
 }
 
 func (val *metadataSystem) Reset() {
@@ -565,6 +565,7 @@ func (val *metadataSystem) Reset() {
 	val.DeprecatedHostname.Reset()
 	val.Kubernetes.Reset()
 	val.Platform.Reset()
+	val.HostId.Reset()
 }
 
 func (val *metadataSystem) validate() error {
@@ -592,6 +593,9 @@ func (val *metadataSystem) validate() error {
 	}
 	if val.Platform.IsSet() && utf8.RuneCountInString(val.Platform.Val) > 1024 {
 		return fmt.Errorf("'platform': validation rule 'maxLength(1024)' violated")
+	}
+	if val.HostId.IsSet() && utf8.RuneCountInString(val.HostId.Val) > 1024 {
+		return fmt.Errorf("'host_id': validation rule 'maxLength(1024)' violated")
 	}
 	return nil
 }


### PR DESCRIPTION
Implementation for https://github.com/elastic/apm/pull/853, closes #187 .

We already support the [OpenTelemetry Resource Attribute host.id](https://opentelemetry.io/docs/specs/semconv/resource/host/) via the OTLP intake. Because this field is required for the universal profiling correlation, we need to be able to set that field via `IntakeV2`.
This PR therefore adds the optional `host_id` as new IntakeV2 metadata field.