### PR TITLE
Support events without domain attr

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -37,6 +37,7 @@ package otlp
 import (
 	"context"
 	"encoding/hex"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -212,7 +213,7 @@ func (c *Consumer) convertLogRecord(
 		)
 	}
 
-	if eventDomain == "device" && eventName != "" {
+	if (eventDomain == "device" && eventName != "") || strings.HasPrefix(eventName, "device.") {
 		event.Event.Category = "device"
 		if eventName == "crash" {
 			if event.Error == nil {
@@ -221,7 +222,7 @@ func (c *Consumer) convertLogRecord(
 			event.Error.Type = "crash"
 		} else {
 			event.Event.Kind = "event"
-			event.Event.Action = eventName
+			event.Event.Action = strings.TrimPrefix(eventName, "device.")
 		}
 	}
 

--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -215,14 +215,15 @@ func (c *Consumer) convertLogRecord(
 
 	if (eventDomain == "device" && eventName != "") || strings.HasPrefix(eventName, "device.") {
 		event.Event.Category = "device"
-		if eventName == "crash" {
+		action := strings.TrimPrefix(eventName, "device.")
+		if action == "crash" {
 			if event.Error == nil {
 				event.Error = modelpb.ErrorFromVTPool()
 			}
 			event.Error.Type = "crash"
 		} else {
 			event.Event.Kind = "event"
-			event.Event.Action = strings.TrimPrefix(eventName, "device.")
+			event.Event.Action = action
 		}
 	}
 


### PR DESCRIPTION
The `event.domain` attribute was removed from the semconv spec [here](https://github.com/open-telemetry/semantic-conventions/pull/473) and, the values that would otherwise be set into the `event.domain` attribute, must now be set as a namespace to the `event.name` value.

This PR is to make apm-data aware of this change while keeping backward compatibility, so that both implementations are properly identified as events.