### PR TITLE
Remap OTel hostmetrics to Elastic metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/apm-data
 go 1.21.1
 
 require (
-	github.com/elastic/opentelemetry-lib v0.0.0-20240520143123-3234f90c8fca
+	github.com/elastic/opentelemetry-lib v0.0.0-20240604140721-08863a456d6c
 	github.com/google/go-cmp v0.6.0
 	github.com/jaegertracing/jaeger v1.56.0
 	github.com/json-iterator/go v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/elastic/apm-data
 
-go 1.21
+go 1.21.1
 
 require (
+	github.com/elastic/opentelemetry-lib v0.0.0-20240520143123-3234f90c8fca
 	github.com/google/go-cmp v0.6.0
 	github.com/jaegertracing/jaeger v1.56.0
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
-github.com/elastic/opentelemetry-lib v0.0.0-20240520143123-3234f90c8fca h1:LM2sFnvnkQP9txkkdMr7kVQiKGtWNJl+yZECsEGacCA=
-github.com/elastic/opentelemetry-lib v0.0.0-20240520143123-3234f90c8fca/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
 github.com/elastic/opentelemetry-lib v0.0.0-20240604140721-08863a456d6c h1:gRCjiqyIH1RxEYAJr1z9Y3KdJITip45iPprj7DbL9Mk=
 github.com/elastic/opentelemetry-lib v0.0.0-20240604140721-08863a456d6c/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUt
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
 github.com/elastic/opentelemetry-lib v0.0.0-20240520143123-3234f90c8fca h1:LM2sFnvnkQP9txkkdMr7kVQiKGtWNJl+yZECsEGacCA=
 github.com/elastic/opentelemetry-lib v0.0.0-20240520143123-3234f90c8fca/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
+github.com/elastic/opentelemetry-lib v0.0.0-20240604140721-08863a456d6c h1:gRCjiqyIH1RxEYAJr1z9Y3KdJITip45iPprj7DbL9Mk=
+github.com/elastic/opentelemetry-lib v0.0.0-20240604140721-08863a456d6c/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
+github.com/elastic/opentelemetry-lib v0.0.0-20240520143123-3234f90c8fca h1:LM2sFnvnkQP9txkkdMr7kVQiKGtWNJl+yZECsEGacCA=
+github.com/elastic/opentelemetry-lib v0.0.0-20240520143123-3234f90c8fca/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/input/otlp/metrics.go
+++ b/input/otlp/metrics.go
@@ -146,7 +146,6 @@ func (c *Consumer) handleScopeMetrics(
 	}
 	// Handle remapping if any. Remapped metrics will be added to a new
 	// metric slice and then processed as any other metric in the scope.
-	// TODO (lahsivjar): Possible to approximate capacity of the slice?
 	if len(c.remappers) > 0 {
 		remappedMetrics := pmetric.NewMetricSlice()
 		for _, r := range c.remappers {

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -54,6 +54,7 @@ import (
 
 	"github.com/elastic/apm-data/input/otlp"
 	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/opentelemetry-lib/remappers/common"
 )
 
 func TestConsumer_ConsumeMetrics_Interface(t *testing.T) {
@@ -919,7 +920,7 @@ func TestConsumeMetricsWithOTelRemapper(t *testing.T) {
 				},
 			},
 			Labels: map[string]*modelpb.LabelValue{
-				"event.provider": &modelpb.LabelValue{Value: "hostmetrics"},
+				"event.module": &modelpb.LabelValue{Value: common.RemapperEventModule},
 			},
 		},
 	}

--- a/model/modelprocessor/datastream.go
+++ b/model/modelprocessor/datastream.go
@@ -141,10 +141,18 @@ func metricsetDataset(event *modelpb.APMEvent) string {
 		// metrics that we don't already know about; otherwise they will end
 		// up creating service-specific data streams.
 		internal := true
-		for _, s := range event.Metricset.Samples {
-			if !IsInternalMetricName(s.Name) {
-				internal = false
-				break
+
+		// set internal to false for metrics translated using OTel remappers.
+		if label, ok := event.Labels["event.provider"]; ok && label != nil {
+			internal = !(label.Value == "hostmetrics")
+		}
+
+		if internal {
+			for _, s := range event.Metricset.Samples {
+				if !IsInternalMetricName(s.Name) {
+					internal = false
+					break
+				}
 			}
 		}
 		if internal {

--- a/model/modelprocessor/datastream.go
+++ b/model/modelprocessor/datastream.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/opentelemetry-lib/remappers/common"
 )
 
 const (
@@ -143,8 +144,8 @@ func metricsetDataset(event *modelpb.APMEvent) string {
 		internal := true
 
 		// set internal to false for metrics translated using OTel remappers.
-		if label, ok := event.Labels["event.provider"]; ok && label != nil {
-			internal = !(label.Value == "hostmetrics")
+		if label, ok := event.Labels["event.module"]; ok && label != nil {
+			internal = !(label.Value == common.RemapperEventModule)
 		}
 
 		if internal {

--- a/model/modelprocessor/datastream_test.go
+++ b/model/modelprocessor/datastream_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/elastic/apm-data/model/modelprocessor"
+	"github.com/elastic/opentelemetry-lib/remappers/common"
 )
 
 func TestSetDataStream(t *testing.T) {
@@ -206,7 +207,7 @@ func TestSetDataStream(t *testing.T) {
 				},
 			},
 			Labels: map[string]*modelpb.LabelValue{
-				"event.provider": &modelpb.LabelValue{Value: "hostmetrics"}, // otel translated hostmetrics
+				"event.module": &modelpb.LabelValue{Value: common.RemapperEventModule}, // otel translated hostmetrics
 			},
 		},
 		output: &modelpb.DataStream{Type: "metrics", Dataset: "apm.app.service_name", Namespace: "custom"},

--- a/model/modelprocessor/datastream_test.go
+++ b/model/modelprocessor/datastream_test.go
@@ -196,6 +196,34 @@ func TestSetDataStream(t *testing.T) {
 			},
 		},
 		output: &modelpb.DataStream{Type: "metrics", Dataset: "apm.internal", Namespace: "custom"},
+	}, {
+		input: &modelpb.APMEvent{
+			Agent:   &modelpb.Agent{Name: "otel"},
+			Service: &modelpb.Service{Name: "service-name"},
+			Metricset: &modelpb.Metricset{
+				Samples: []*modelpb.MetricsetSample{
+					{Name: "system.memory.total"},
+				},
+			},
+			Labels: map[string]*modelpb.LabelValue{
+				"event.provider": &modelpb.LabelValue{Value: "hostmetrics"}, // otel translated hostmetrics
+			},
+		},
+		output: &modelpb.DataStream{Type: "metrics", Dataset: "apm.app.service_name", Namespace: "custom"},
+	}, {
+		input: &modelpb.APMEvent{
+			Agent:   &modelpb.Agent{Name: "otel"},
+			Service: &modelpb.Service{Name: "service-name"},
+			Metricset: &modelpb.Metricset{
+				Samples: []*modelpb.MetricsetSample{
+					{Name: "system.memory.total"},
+				},
+			},
+			Labels: map[string]*modelpb.LabelValue{
+				"event.provider": &modelpb.LabelValue{Value: "kernel"},
+			},
+		},
+		output: &modelpb.DataStream{Type: "metrics", Dataset: "apm.internal", Namespace: "custom"},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
The PR uses the library [opentelemetry-lib](https://github.com/elastic/opentelemetry-lib/) to remap metrics produced by [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md) to Elastic metrics that could power the curated UIs.

<details>
<summary>Example OTel collector configuration required to get the remapping working</summary>

```yaml
receivers:
  hostmetrics:
    collection_interval: 10s
    scrapers:
      load:
      cpu:
        metrics:
          system.cpu.utilization:
            enabled: true
          system.cpu.logical.count:
            enabled: true
      memory:
        metrics:
          system.memory.utilization:
            enabled: true
      network:
      process:
        metrics:
          process.threads:
            enabled: true
          process.open_file_descriptors:
            enabled: true
          process.memory.utilization:
            enabled: true
          process.disk.operations:
            enabled: true
      processes:

exporters:
  otlphttp:
    endpoint: http://192.168.0.44:8200
    tls:
      insecure: true
  debug:
    verbosity: detailed

processors:
  resourcedetection/system:
    detectors: ["system"]
    system:
      hostname_sources: ["os"]

service:
  pipelines:
    metrics:
      receivers: [hostmetrics]
      processors: [resourcedetection/system]
      exporters: [otlphttp, debug]
```
</details>

## Related issues

- https://github.com/elastic/opentelemetry-dev/issues/217
- https://github.com/elastic/opentelemetry-dev/issues/180