### PR TITLE
Enable k8s otel metrics remapping to elastic metrics

### DIFF
--- a/input/otlp/consumer.go
+++ b/input/otlp/consumer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/apm-data/input"
 	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/elastic/opentelemetry-lib/remappers/hostmetrics"
+	"github.com/elastic/opentelemetry-lib/remappers/kubernetesmetrics"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -72,6 +73,7 @@ func NewConsumer(config ConsumerConfig) *Consumer {
 	if config.RemapOTelMetrics {
 		remappers = []remapper{
 			hostmetrics.NewRemapper(config.Logger),
+			kubernetesmetrics.NewRemapper(config.Logger),
 		}
 	}
 	return &Consumer{


### PR DESCRIPTION
The PR enables k8s metrics remapping.

Similar to https://github.com/elastic/apm-data/pull/277

## Related issues

- https://github.com/elastic/opentelemetry-dev/issues/217
- https://github.com/elastic/opentelemetry-dev/issues/180