### PR TITLE
feat: support latest `messaging.destination.name` attribute

### DIFF
--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -439,7 +439,11 @@ func TranslateTransaction(
 				event.Network.Carrier.Icc = stringval
 
 			// messaging.*
-			case "message_bus.destination", semconv.AttributeMessagingDestination:
+			//
+			// messaging.destination is now called messaging.destination.name in the latest semconv
+			// https://opentelemetry.io/docs/specs/semconv/attributes-registry/messaging
+			// keep both of them for the backward compatibility
+			case "message_bus.destination", semconv.AttributeMessagingDestination, "messaging.destination.name":
 				isMessaging = true
 				messagingQueueName = stringval
 			case semconv.AttributeMessagingSystem:
@@ -784,7 +788,11 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 				event.Session.Id = stringval
 
 			// messaging.*
-			case "message_bus.destination", semconv.AttributeMessagingDestination:
+			//
+			// messaging.destination is now called messaging.destination.name in the latest semconv
+			// https://opentelemetry.io/docs/specs/semconv/attributes-registry/messaging
+			// keep both of them for the backward compatibility
+			case "message_bus.destination", semconv.AttributeMessagingDestination, "messaging.destination.name":
 				message.QueueName = stringval
 				isMessaging = true
 			case semconv.AttributeMessagingOperation:


### PR DESCRIPTION
addresses #284 

latest semconv attributes introduced `messaging.destination.name` to replace `messaging.destination`.
This PR will support the latest semconv attribute for mapping while keep supporting the old attribute for backward compatibility.

note: updating the semconv to the latest is not done due to the lack of defined process [issue](https://github.com/elastic/apm-data/issues/116)