### PR TITLE
Update opentelemetry-lib to v0.3.0 and fix issue with taint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/apm-data
 go 1.21.1
 
 require (
-	github.com/elastic/opentelemetry-lib v0.2.0
+	github.com/elastic/opentelemetry-lib v0.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/jaegertracing/jaeger v1.58.0
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUt
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
 github.com/elastic/opentelemetry-lib v0.2.0 h1:iebyZVwhCh32J+xJtzjXK2LRWbrcyO/XhTxi5j8rUmc=
 github.com/elastic/opentelemetry-lib v0.2.0/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
+github.com/elastic/opentelemetry-lib v0.3.0 h1:5wmnCqEajieIae71vh4oET0P0LX6Tb+pY09D9dDv1wA=
+github.com/elastic/opentelemetry-lib v0.3.0/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -54,7 +54,6 @@ import (
 
 	"github.com/elastic/apm-data/input/otlp"
 	"github.com/elastic/apm-data/model/modelpb"
-	"github.com/elastic/opentelemetry-lib/remappers/common"
 )
 
 func TestConsumer_ConsumeMetrics_Interface(t *testing.T) {
@@ -920,7 +919,7 @@ func TestConsumeMetricsWithOTelRemapper(t *testing.T) {
 				},
 			},
 			Labels: map[string]*modelpb.LabelValue{
-				"event.module": &modelpb.LabelValue{Value: common.RemapperEventModule},
+				"otel_remapped": &modelpb.LabelValue{Value: "true"},
 			},
 		},
 	}

--- a/model/modelprocessor/datastream.go
+++ b/model/modelprocessor/datastream.go
@@ -20,10 +20,10 @@ package modelprocessor
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/elastic/apm-data/model/modelpb"
-	"github.com/elastic/opentelemetry-lib/remappers/common"
 )
 
 const (
@@ -144,8 +144,9 @@ func metricsetDataset(event *modelpb.APMEvent) string {
 		internal := true
 
 		// set internal to false for metrics translated using OTel remappers.
-		if label, ok := event.Labels["event.module"]; ok && label != nil {
-			internal = !(label.Value == common.RemapperEventModule)
+		if label, ok := event.Labels["otel_remapped"]; ok && label != nil {
+			remapped, _ := strconv.ParseBool(label.Value)
+			internal = !remapped
 		}
 
 		if internal {

--- a/model/modelprocessor/datastream_test.go
+++ b/model/modelprocessor/datastream_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/elastic/apm-data/model/modelprocessor"
-	"github.com/elastic/opentelemetry-lib/remappers/common"
 )
 
 func TestSetDataStream(t *testing.T) {
@@ -207,7 +206,7 @@ func TestSetDataStream(t *testing.T) {
 				},
 			},
 			Labels: map[string]*modelpb.LabelValue{
-				"event.module": &modelpb.LabelValue{Value: common.RemapperEventModule}, // otel translated hostmetrics
+				"otel_remapped": &modelpb.LabelValue{Value: "true"}, // otel translated hostmetrics
 			},
 		},
 		output: &modelpb.DataStream{Type: "metrics", Dataset: "apm.app.service_name", Namespace: "custom"},


### PR DESCRIPTION
PR https://github.com/elastic/opentelemetry-lib/pull/30 updated the taint to use a custom non-ecs field. This PR updates the code in accordance.