### PR TITLE
Bump up opentelemetry-lib to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/apm-data
 go 1.21.1
 
 require (
-	github.com/elastic/opentelemetry-lib v0.7.0
+	github.com/elastic/opentelemetry-lib v0.7.1
 	github.com/google/go-cmp v0.6.0
 	github.com/jaegertracing/jaeger v1.58.1
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
-github.com/elastic/opentelemetry-lib v0.7.0 h1:sarbwqZJ9sx+B1zUl6qmf93/j7ggDAidc5CYKsIsQQk=
-github.com/elastic/opentelemetry-lib v0.7.0/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
+github.com/elastic/opentelemetry-lib v0.7.1 h1:eD3j/tyqSfOsPllqWRd56fgev39m2FNqvaxjqn0Uoi4=
+github.com/elastic/opentelemetry-lib v0.7.1/go.mod h1:/kKvHbJLVo/NcKMPHI8/RZKL64fushmnRUzn+arQpjg=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -936,8 +936,10 @@ func TestConsumeMetricsWithOTelRemapper(t *testing.T) {
 			name: "process",
 			input: func() pmetric.Metrics {
 				metrics := pmetric.NewMetrics()
-				sm := metrics.ResourceMetrics().AppendEmpty().
-					ScopeMetrics().AppendEmpty()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				rm.Resource().Attributes().PutStr("process.owner", "testowner")
+				rm.Resource().Attributes().PutStr("process.command_line", "testcmdline")
+				sm := rm.ScopeMetrics().AppendEmpty()
 				sm.Scope().SetName("otelcol/hostmetricsreceiver/process")
 
 				metric := sm.Metrics().AppendEmpty()
@@ -957,6 +959,12 @@ func TestConsumeMetricsWithOTelRemapper(t *testing.T) {
 					},
 					Agent:     &modelpb.Agent{Name: "otlp", Version: "unknown"},
 					Timestamp: modelpb.FromTime(ts),
+					Process: &modelpb.Process{
+						CommandLine: "testcmdline",
+					},
+					User: &modelpb.User{
+						Name: "testowner",
+					},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
@@ -1050,9 +1058,16 @@ func TestConsumeMetricsWithOTelRemapper(t *testing.T) {
 							},
 						},
 					},
+					Process: &modelpb.Process{
+						CommandLine: "testcmdline",
+					},
+					User: &modelpb.User{
+						Name: "testowner",
+					},
 					System: &modelpb.System{
 						Process: &modelpb.SystemProcess{
-							State: "undefined",
+							State:   "undefined",
+							Cmdline: "testcmdline",
 							Cpu: &modelpb.SystemProcessCPU{
 								StartTime: startTs.Format(time.RFC3339),
 							},
@@ -1060,6 +1075,9 @@ func TestConsumeMetricsWithOTelRemapper(t *testing.T) {
 					},
 					Labels: map[string]*modelpb.LabelValue{
 						"otel_remapped": &modelpb.LabelValue{Value: "true"},
+						// This is set as labels too since the opentelemetry-lib
+						// adds `user.name` label to datapoints causing duplicates.
+						"user.name": &modelpb.LabelValue{Value: "true"},
 					},
 					Event: &modelpb.Event{
 						Dataset: "system.process",

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -1077,7 +1077,7 @@ func TestConsumeMetricsWithOTelRemapper(t *testing.T) {
 						"otel_remapped": &modelpb.LabelValue{Value: "true"},
 						// This is set as labels too since the opentelemetry-lib
 						// adds `user.name` label to datapoints causing duplicates.
-						"user.name": &modelpb.LabelValue{Value: "true"},
+						"user.name": &modelpb.LabelValue{Value: "testowner"},
 					},
 					Event: &modelpb.Event{
 						Dataset: "system.process",


### PR DESCRIPTION
Fixes the bug with hostmetrics UI breaking due to missing `user.name` and `system.process.cmdline` fields.