### PR TITLE
Allow datapoint attributes to override user.name

### DIFF
--- a/input/otlp/metrics.go
+++ b/input/otlp/metrics.go
@@ -240,6 +240,11 @@ func (c *Consumer) handleScopeMetrics(
 						event.Event = modelpb.EventFromVTPool()
 					}
 					event.Event.Dataset = v.Str()
+				case "user.name":
+					if event.User == nil {
+						event.User = modelpb.UserFromVTPool()
+					}
+					event.User.Name = truncate(v.Str())
 				default:
 					setLabel(k, event, ifaceAttributeValue(v))
 				}

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -1075,9 +1075,6 @@ func TestConsumeMetricsWithOTelRemapper(t *testing.T) {
 					},
 					Labels: map[string]*modelpb.LabelValue{
 						"otel_remapped": &modelpb.LabelValue{Value: "true"},
-						// This is set as labels too since the opentelemetry-lib
-						// adds `user.name` label to datapoints causing duplicates.
-						"user.name": &modelpb.LabelValue{Value: "testowner"},
 					},
 					Event: &modelpb.Event{
 						Dataset: "system.process",


### PR DESCRIPTION
With https://github.com/elastic/opentelemetry-lib/pull/42, otel-lib sets a default non-empty value to `user.name`. This has been done to allow the UI to not crash if the field is missing for certain setups. Due to this change, APM-data needs to allow the `user.name` to be overridden as data-point attributes.