### PR TITLE
Add support for is_child in addition to elastic.is_child SpanLink attribute

### DIFF
--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -1269,8 +1269,10 @@ func translateSpanLinks(out *modelpb.APMEvent, in ptrace.SpanLinkSlice) {
 	for i := 0; i < n; i++ {
 		link := in.At(i)
 		// When a link has the elastic.is_child attribute set, it is stored in the child_ids instead
-		childAttribVal, childAttribPresent := link.Attributes().Get("elastic.is_child")
-		if childAttribPresent && childAttribVal.Bool() {
+		elChildAttribVal, elChildAttribPresent := link.Attributes().Get("elastic.is_child")
+		// alternatively, we also look for just "is_child" without the elastic. prefix
+		childAttribVal, childAttribPresent := link.Attributes().Get("is_child")
+		if (elChildAttribPresent && elChildAttribVal.Bool()) || (childAttribPresent && childAttribVal.Bool()) {
 			out.ChildIds = append(out.ChildIds, hexSpanID(link.SpanID()))
 		} else {
 			sl := modelpb.SpanLinkFromVTPool()

--- a/input/otlp/traces_test.go
+++ b/input/otlp/traces_test.go
@@ -1055,18 +1055,25 @@ func TestSpanLinks(t *testing.T) {
 	spanLink.SetSpanID(linkedSpanID)
 	spanLink.SetTraceID(linkedTraceID)
 
-	childSpanID := pcommon.SpanID{16, 17, 18, 19, 20, 21, 22, 23}
-	childLink := ptrace.NewSpanLink()
-	childLink.SetSpanID(childSpanID)
-	childLink.SetTraceID(linkedTraceID)
-	childLink.Attributes().PutBool("elastic.is_child", true)
+	childSpanID1 := pcommon.SpanID{16, 17, 18, 19, 20, 21, 22, 23}
+	childLink1 := ptrace.NewSpanLink()
+	childLink1.SetSpanID(childSpanID1)
+	childLink1.SetTraceID(linkedTraceID)
+	childLink1.Attributes().PutBool("elastic.is_child", true)
+
+	childSpanID2 := pcommon.SpanID{24, 25, 26, 27, 28, 29, 30, 31}
+	childLink2 := ptrace.NewSpanLink()
+	childLink2.SetSpanID(childSpanID2)
+	childLink2.SetTraceID(linkedTraceID)
+	childLink2.Attributes().PutBool("is_child", true)
 
 	txEvent := transformTransactionWithAttributes(t, map[string]interface{}{}, func(span ptrace.Span) {
 		spanLink.CopyTo(span.Links().AppendEmpty())
 	})
 	spanEvent := transformSpanWithAttributes(t, map[string]interface{}{}, func(span ptrace.Span) {
 		spanLink.CopyTo(span.Links().AppendEmpty())
-		childLink.CopyTo(span.Links().AppendEmpty())
+		childLink1.CopyTo(span.Links().AppendEmpty())
+		childLink2.CopyTo(span.Links().AppendEmpty())
 	})
 	for _, event := range []*modelpb.APMEvent{txEvent, spanEvent} {
 		assert.Equal(t, []*modelpb.SpanLink{{
@@ -1074,7 +1081,7 @@ func TestSpanLinks(t *testing.T) {
 			TraceId: "000102030405060708090a0b0c0d0e0f",
 		}}, event.Span.Links)
 	}
-	assert.Equal(t, spanEvent.ChildIds, []string{"1011121314151617"})
+	assert.Equal(t, spanEvent.ChildIds, []string{"1011121314151617", "18191a1b1c1d1e1f"})
 }
 
 func TestConsumeTracesSemaphore(t *testing.T) {


### PR DESCRIPTION
#185 added support for receiving inferred-span with our vendor-specific [OpenTelemetry inferred-spans extension](https://github.com/elastic/elastic-otel-java/tree/main/inferred-spans).

We recently contributed that [extension upstream](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/inferred-spans). In that process, we changed the SpanLink attribute for overriding parent-child relationships from `elastic.is_child` to just `is_child`. Therefor, apm-server needs to support both `elastic.is_child` and `is_child`.