### PR TITLE
Fix host.ip 0.0.0.0 treated as invalid

### DIFF
--- a/model/modelpb/ip.go
+++ b/model/modelpb/ip.go
@@ -56,6 +56,9 @@ func Addr2IP(addr netip.Addr) *IP {
 
 // IP2Addr converts a valid IP to netip.Addr.
 func IP2Addr(i *IP) netip.Addr {
+	if i == nil {
+		return netip.Addr{}
+	}
 	if addr := i.GetV6(); len(addr) == 16 {
 		return netip.AddrFrom16([16]byte(addr))
 	}

--- a/model/modelpb/ip.go
+++ b/model/modelpb/ip.go
@@ -41,6 +41,7 @@ func MustParseIP(s string) *IP {
 	return ip
 }
 
+// Addr2IP converts a valid netip.Addr to IP.
 func Addr2IP(addr netip.Addr) *IP {
 	if addr.Is4() {
 		ip := IPFromVTPool()
@@ -53,16 +54,14 @@ func Addr2IP(addr netip.Addr) *IP {
 	return ip
 }
 
+// IP2Addr converts a valid IP to netip.Addr.
 func IP2Addr(i *IP) netip.Addr {
 	if addr := i.GetV6(); len(addr) == 16 {
 		return netip.AddrFrom16([16]byte(addr))
 	}
-	if i.GetV4() != 0 {
-		var addr [4]byte
-		binary.BigEndian.PutUint32(addr[:], i.V4)
-		return netip.AddrFrom4(addr)
-	}
-	return netip.Addr{}
+	var addr [4]byte
+	binary.BigEndian.PutUint32(addr[:], i.V4)
+	return netip.AddrFrom4(addr)
 }
 
 func IP2String(i *IP) string {

--- a/model/modelpb/ip.go
+++ b/model/modelpb/ip.go
@@ -54,7 +54,7 @@ func Addr2IP(addr netip.Addr) *IP {
 	return ip
 }
 
-// IP2Addr converts a valid IP to netip.Addr.
+// IP2Addr converts a nil IP to a zero netip.Addr and a valid IP to a valid netip.Addr.
 func IP2Addr(i *IP) netip.Addr {
 	if i == nil {
 		return netip.Addr{}

--- a/model/modelpb/ip_test.go
+++ b/model/modelpb/ip_test.go
@@ -124,16 +124,28 @@ func TestAddr2IP(t *testing.T) {
 		expectedIP *IP
 	}{
 		{
-			name:    "with an IPv4 address",
+			name:    "IPv4 address 127.0.0.1",
 			address: netip.MustParseAddr("127.0.0.1"),
 
 			expectedIP: MustParseIP("127.0.0.1"),
 		},
 		{
-			name:    "with an IPv6 address",
+			name:    "IPv6 address 0.0.0.0",
+			address: netip.MustParseAddr("0.0.0.0"),
+
+			expectedIP: MustParseIP("0.0.0.0"),
+		},
+		{
+			name:    "IPv6 address ::1",
 			address: netip.MustParseAddr("::1"),
 
 			expectedIP: MustParseIP("::1"),
+		},
+		{
+			name:    "IPv6 address ::",
+			address: netip.MustParseAddr("::"),
+
+			expectedIP: MustParseIP("::"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -152,16 +164,28 @@ func TestIP2Addr(t *testing.T) {
 		expectedAddr netip.Addr
 	}{
 		{
-			name: "with an IPv4 address",
+			name: "IPv4 address 127.0.0.1",
 			ip:   MustParseIP("127.0.0.1"),
 
 			expectedAddr: netip.MustParseAddr("127.0.0.1"),
 		},
 		{
-			name: "with an IPv6 address",
+			name: "IPv4 address 0.0.0.0",
+			ip:   MustParseIP("0.0.0.0"),
+
+			expectedAddr: netip.MustParseAddr("0.0.0.0"),
+		},
+		{
+			name: "IPv6 address ::1",
 			ip:   MustParseIP("::1"),
 
 			expectedAddr: netip.MustParseAddr("::1"),
+		},
+		{
+			name: "IPv6 address ::",
+			ip:   MustParseIP("::"),
+
+			expectedAddr: netip.MustParseAddr("::"),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
`host.ip` is parsed from resource attribute `ip` when resource attribute `opencensus.exporterversion` has prefix `Jaeger`. This PR fixes the incorrect handling of value `0.0.0.0` of this field.
