### PR TITLE
Ensure more unique grouping key when parsed stack trace is not available.

### DIFF
--- a/model/modelprocessor/groupingkey.go
+++ b/model/modelprocessor/groupingkey.go
@@ -56,7 +56,11 @@ func (s SetGroupingKey) processError(ctx context.Context, event *modelpb.Error) 
 	}
 	var haveExceptionStacktrace bool
 	if event.Exception != nil {
-		haveExceptionStacktrace = s.hashExceptionTree(event.Exception, hash, s.hashExceptionStacktrace)
+		if s.exceptionTreeHasStackTrace(event.Exception) {
+			haveExceptionStacktrace = s.hashExceptionTree(event.Exception, hash, s.hashExceptionStacktrace)
+		} else {
+			haveExceptionStacktrace = s.hashExceptionTree(event.Exception, hash, s.hashExceptionMessage)
+		}
 		updated = updated || haveExceptionStacktrace
 	}
 	if !haveExceptionStacktrace && event.Log != nil {
@@ -71,8 +75,25 @@ func (s SetGroupingKey) processError(ctx context.Context, event *modelpb.Error) 
 		if !updated && event.Log != nil {
 			s.maybeWriteString(event.Log.Message, hash)
 		}
+		// if all else false hash over stacktrace
+		if !updated {
+			s.maybeWriteString(event.StackTrace, hash)
+		}
 	}
 	event.GroupingKey = hex.EncodeToString(hash.Sum(nil))
+}
+
+func (s SetGroupingKey) exceptionTreeHasStackTrace(e *modelpb.Exception) bool {
+	updated := e.Stacktrace != nil
+	if updated {
+		return updated
+	}
+	for _, cause := range e.Cause {
+		if s.exceptionTreeHasStackTrace(cause) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s SetGroupingKey) hashExceptionTree(e *modelpb.Exception, out hash.Hash, f func(*modelpb.Exception, hash.Hash) bool) bool {


### PR DESCRIPTION
OpenTelemetry today just sends a tree of `exception.message` and `exception.type`

The current logic for `haveExceptionStackTrace` determines there is a stack trace if there is an
exception tree.

This PR ensures that when an exception tree has no stacktrace anywhere in the tree we include
`exception.message` into the hash so that we don't just hash over `exception.type`.
