### PR TITLE
Fix OTEL Exception Message Propagation

### DIFF
--- a/model/modelprocessor/errormessage.go
+++ b/model/modelprocessor/errormessage.go
@@ -33,6 +33,9 @@ func (s SetErrorMessage) ProcessBatch(ctx context.Context, b *modelpb.Batch) err
 		event := (*b)[i]
 		if event.Error != nil {
 			event.Error.Message = s.setErrorMessage(event)
+			if event.GetMessage() == "" {
+				event.Message = event.Error.Message
+			}
 		}
 	}
 	return nil

--- a/model/modelprocessor/errormessage.go
+++ b/model/modelprocessor/errormessage.go
@@ -32,9 +32,8 @@ func (s SetErrorMessage) ProcessBatch(ctx context.Context, b *modelpb.Batch) err
 	for i := range *b {
 		event := (*b)[i]
 		if event.Error != nil {
-			event.Error.Message = s.setErrorMessage(event)
 			if event.GetMessage() == "" {
-				event.Message = event.Error.Message
+				event.Message = s.setErrorMessage(event)
 			}
 		}
 	}

--- a/model/modelprocessor/errormessage.go
+++ b/model/modelprocessor/errormessage.go
@@ -32,7 +32,7 @@ func (s SetErrorMessage) ProcessBatch(ctx context.Context, b *modelpb.Batch) err
 	for i := range *b {
 		event := (*b)[i]
 		if event.Error != nil {
-			event.Message = s.setErrorMessage(event)
+			event.Error.Message = s.setErrorMessage(event)
 		}
 	}
 	return nil

--- a/model/modelprocessor/errormessage_test.go
+++ b/model/modelprocessor/errormessage_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/elastic/apm-data/model/modelprocessor"
 )
 
-func TestSetEventMessage(t *testing.T) {
+func TestSetErrorMessage(t *testing.T) {
 	tests := []struct {
 		desc            string
 		input           *modelpb.APMEvent

--- a/model/modelprocessor/errormessage_test.go
+++ b/model/modelprocessor/errormessage_test.go
@@ -27,38 +27,90 @@ import (
 	"github.com/elastic/apm-data/model/modelprocessor"
 )
 
+// Copy the error message to the event message if event message is empty.
 func TestSetErrorMessage(t *testing.T) {
 	tests := []struct {
-		input   *modelpb.Error
-		message string
+		input    *modelpb.Error
+		expected string
 	}{{
-		input:   &modelpb.Error{},
-		message: "",
+		input:    &modelpb.Error{},
+		expected: "",
 	}, {
-		input:   &modelpb.Error{Log: &modelpb.ErrorLog{Message: "log_message"}},
-		message: "log_message",
+		input:    &modelpb.Error{Log: &modelpb.ErrorLog{Message: "log_message"}},
+		expected: "log_message",
 	}, {
-		input:   &modelpb.Error{Exception: &modelpb.Exception{Message: "exception_message"}},
-		message: "exception_message",
+		input:    &modelpb.Error{Exception: &modelpb.Exception{Message: "exception_message"}},
+		expected: "exception_message",
 	}, {
 		input: &modelpb.Error{
 			Log:       &modelpb.ErrorLog{},
 			Exception: &modelpb.Exception{Message: "exception_message"},
 		},
-		message: "exception_message",
+		expected: "exception_message",
 	}, {
 		input: &modelpb.Error{
 			Log:       &modelpb.ErrorLog{Message: "log_message"},
 			Exception: &modelpb.Exception{Message: "exception_message"},
 		},
-		message: "log_message",
+		expected: "log_message",
 	}}
-
 	for _, test := range tests {
 		batch := modelpb.Batch{{Error: test.input}}
 		processor := modelprocessor.SetErrorMessage{}
 		err := processor.ProcessBatch(context.Background(), &batch)
 		assert.NoError(t, err)
-		assert.Equal(t, test.message, batch[0].Error.Message)
+		assert.Equal(t, test.expected, batch[0].Message)
+		assert.Equal(t, test.expected, batch[0].Error.Message)
+	}
+}
+
+// If event message is non-empty, do not override with error message.
+func TestSetEventMessage(t *testing.T) {
+	tests := []struct {
+		input    *modelpb.APMEvent
+		expected string
+	}{{
+		input: &modelpb.APMEvent{
+			Message: "message",
+		},
+		expected: "message",
+	}, {
+		input: &modelpb.APMEvent{
+			Error:   &modelpb.Error{Log: &modelpb.ErrorLog{Message: "log_message"}},
+			Message: "message",
+		},
+		expected: "message",
+	}, {
+		input: &modelpb.APMEvent{
+			Error:   &modelpb.Error{Exception: &modelpb.Exception{Message: "exception_message"}},
+			Message: "message",
+		},
+		expected: "message",
+	}, {
+		input: &modelpb.APMEvent{
+			Error: &modelpb.Error{
+				Log:       &modelpb.ErrorLog{},
+				Exception: &modelpb.Exception{Message: "exception_message"},
+			},
+			Message: "message",
+		},
+		expected: "message",
+	}, {
+		input: &modelpb.APMEvent{
+			Error: &modelpb.Error{
+				Log:       &modelpb.ErrorLog{Message: "log_message"},
+				Exception: &modelpb.Exception{Message: "exception_message"},
+			},
+			Message: "message",
+		},
+		expected: "message",
+	}}
+
+	for _, test := range tests {
+		batch := modelpb.Batch{test.input}
+		processor := modelprocessor.SetErrorMessage{}
+		err := processor.ProcessBatch(context.Background(), &batch)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, batch[0].Message)
 	}
 }

--- a/model/modelprocessor/errormessage_test.go
+++ b/model/modelprocessor/errormessage_test.go
@@ -59,7 +59,6 @@ func TestSetErrorMessage(t *testing.T) {
 		processor := modelprocessor.SetErrorMessage{}
 		err := processor.ProcessBatch(context.Background(), &batch)
 		assert.NoError(t, err)
-		assert.Equal(t, test.message, batch[0].Message)
+		assert.Equal(t, test.message, batch[0].Error.Message)
 	}
-
 }

--- a/model/modelprocessor/errormessage_test.go
+++ b/model/modelprocessor/errormessage_test.go
@@ -29,11 +29,9 @@ import (
 
 func TestSetEventMessage(t *testing.T) {
 	tests := []struct {
-		desc                     string
-		input                    *modelpb.APMEvent
-		expectedMessage          string
-		expectedLogMessage       string
-		expectedExceptionMessage string
+		desc            string
+		input           *modelpb.APMEvent
+		expectedMessage string
 	}{{
 		desc: "keep event message when no error",
 		input: &modelpb.APMEvent{
@@ -43,9 +41,7 @@ func TestSetEventMessage(t *testing.T) {
 			},
 			Message: "message",
 		},
-		expectedMessage:          "message",
-		expectedLogMessage:       "",
-		expectedExceptionMessage: "",
+		expectedMessage: "message",
 	}, {
 		desc: "keep event message when error",
 		input: &modelpb.APMEvent{
@@ -55,9 +51,7 @@ func TestSetEventMessage(t *testing.T) {
 			},
 			Message: "message",
 		},
-		expectedMessage:          "message",
-		expectedLogMessage:       "log_message",
-		expectedExceptionMessage: "exception_message",
+		expectedMessage: "message",
 	}, {
 		desc: "propagate log error if event message empty",
 		input: &modelpb.APMEvent{
@@ -67,9 +61,7 @@ func TestSetEventMessage(t *testing.T) {
 			},
 			Message: "",
 		},
-		expectedMessage:          "log_message",
-		expectedLogMessage:       "log_message",
-		expectedExceptionMessage: "",
+		expectedMessage: "log_message",
 	}, {
 		desc: "propagate exception error if event message is empty",
 		input: &modelpb.APMEvent{
@@ -79,9 +71,7 @@ func TestSetEventMessage(t *testing.T) {
 			},
 			Message: "",
 		},
-		expectedMessage:          "exception_message",
-		expectedLogMessage:       "",
-		expectedExceptionMessage: "exception_message",
+		expectedMessage: "exception_message",
 	}}
 
 	for _, test := range tests {
@@ -90,7 +80,5 @@ func TestSetEventMessage(t *testing.T) {
 		err := processor.ProcessBatch(context.Background(), &batch)
 		assert.NoError(t, err)
 		assert.Equal(t, test.expectedMessage, batch[0].Message)
-		assert.Equal(t, test.expectedLogMessage, batch[0].Error.Log.Message)
-		assert.Equal(t, test.expectedExceptionMessage, batch[0].Error.Exception.Message)
 	}
 }


### PR DESCRIPTION
Fix on [Issue 13603](https://github.com/elastic/apm-server/issues/13603)

The issue is reproduced by:

- Running `apm-server` locally.
- Sending OTLP data via the Go client `sendotlp`.
    - Some changes was made to `apm-server/systemtest/cmd/sendotlp`
    - I'll open a PR with this in `apm-server` once this PR is approved
- View the document in Table form in Kibana -> Analytics -> Discover


<img width="877" alt="incorrect" src="https://github.com/user-attachments/assets/61dc8b44-087c-4b3d-aca0-e72323b82d2b">


The issue is fixed by:

- Applying the changes from `apm-data` to `apm-server` 
    - `cd apm-server`
    - `go mod edit -replace=github.com/elastic/apm-data=../apm-data`
    - `make update`
- Redo steps as depicted above.


<img width="905" alt="correct" src="https://github.com/user-attachments/assets/13753964-f28b-42c0-be6e-a04bcef1beb7">