### PR TITLE
Drop invalid array elements in OTLP payload

### DIFF
--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -536,22 +536,22 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 		}
 		switch v[0].(type) {
 		case string:
-			value := make([]string, len(v))
+			value := make([]string, 0, len(v))
 			for i := range v {
 				// Ensure that the array is homogeneous
 				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				if r, ok := v[i].(string); ok {
-					value[i] = r
+					value = append(value, r)
 				}
 			}
 			modelpb.Labels(event.Labels).SetSlice(key, value)
 		case float64:
-			value := make([]float64, len(v))
+			value := make([]float64, 0, len(v))
 			for i := range v {
 				// Ensure that the array is homogeneous
 				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				if r, ok := v[i].(float64); ok {
-					value[i] = r
+					value = append(value, r)
 				}
 			}
 			modelpb.NumericLabels(event.NumericLabels).SetSlice(key, value)

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -539,11 +539,9 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 			value := make([]string, len(v))
 			for i := range v {
 				// Ensure that the array is homogeneous
-				switch r := v[i].(type) {
-				case string:
+				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
+				if r, ok := v[i].(string); ok {
 					value[i] = r
-				default:
-					// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				}
 			}
 			modelpb.Labels(event.Labels).SetSlice(key, value)
@@ -551,11 +549,9 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 			value := make([]float64, len(v))
 			for i := range v {
 				// Ensure that the array is homogeneous
-				switch r := v[i].(type) {
-				case float64:
+				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
+				if r, ok := v[i].(float64); ok {
 					value[i] = r
-				default:
-					// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				}
 			}
 			modelpb.NumericLabels(event.NumericLabels).SetSlice(key, value)

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -538,13 +538,25 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 		case string:
 			value := make([]string, len(v))
 			for i := range v {
-				value[i] = v[i].(string)
+				// Ensure that the array is homogeneous
+				switch r := v[i].(type) {
+				case string:
+					value[i] = r
+				default:
+					// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
+				}
 			}
 			modelpb.Labels(event.Labels).SetSlice(key, value)
 		case float64:
 			value := make([]float64, len(v))
 			for i := range v {
-				value[i] = v[i].(float64)
+				// Ensure that the array is homogeneous
+				switch r := v[i].(type) {
+				case float64:
+					value[i] = r
+				default:
+					// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
+				}
 			}
 			modelpb.NumericLabels(event.NumericLabels).SetSlice(key, value)
 		}


### PR DESCRIPTION
Fixes elastic/apm-server#13703

## Context

The issue occurs due to an invalid OTLP payload. Specifically, an array containing heterogeneous elements.

## APM Server Setup

1. Apply this PR `apm-data` changes to your `apm-server` package:
```
cd apm-server
go mod edit -replace=github.com/elastic/apm-data=../apm-data
````

2. Spin up your local `apm-server` instance

## Example Setup

A Python example had to be used, since the OpenTelemetry Go SDK does not natively support heterogeneous arrays.

- Pull the OTEL Python package that includes a set of examples
```
git clone https://github.com/open-telemetry/opentelemetry-python
cd opentelemetry-python
```

- Save the following patch in `changes.diff`
```
diff --git a/docs/examples/basic_tracer/basic_trace.py b/docs/examples/basic_tracer/basic_trace.py
index bb1e341a..71e84224 100644
--- a/docs/examples/basic_tracer/basic_trace.py
+++ b/docs/examples/basic_tracer/basic_trace.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
-    ConsoleSpanExporter,
 )
 
 trace.set_tracer_provider(TracerProvider())
 trace.get_tracer_provider().add_span_processor(
-    BatchSpanProcessor(ConsoleSpanExporter())
+    BatchSpanProcessor(OTLPSpanExporter("http://localhost:8200/v1/traces"))
 )
 tracer = trace.get_tracer(__name__)
-with tracer.start_as_current_span("foo"):
+with tracer.start_as_current_span("foo", attributes={"foo": ["bar",None]}) as span:
     print("Hello world!")
diff --git a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
index 6593d89f..75d15b52 100644
--- a/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
+++ b/exporter/opentelemetry-exporter-otlp-proto-common/src/opentelemetry/exporter/otlp/proto/common/_internal/__init__.py
@@ -85,6 +85,8 @@ def _encode_value(value: Any) -> PB2AnyValue:
                 values=[_encode_key_value(str(k), v) for k, v in value.items()]
             )
         )
+    elif value is None:
+        return PB2AnyValue()
     raise Exception(f"Invalid type {type(value)} of value {value}")
```

- Apply the patch
```
patch < changes.diff
```

- Create a Python venv
```
python -m venv env
pip install --upgrade pip
```

- Install the `opentelemetry-exporter-otlp*` packages locally from `opentelemetry-python/exporter` folder. For example,
```
cd exporter/opentelemetry-exporter-otlp-proto-grpc
pip install -e .
```

- Run the example
```
cd docs/examples/basic_tracer
python basic_trace.py
```

- Result
```
> Hello world!
```

- Running the Python example without the Patch
```
panic: interface conversion: interface {} is nil, not string
goroutine 3684 [running]:
github.com/elastic/apm-data/input/otlp.setLabel({0xc00502e960, 0x1b}, 0xc003ccef20, {0x1c9da00?, 0xc000ca7710?})
        github.com/elastic/apm-data@v1.1.0/input/otlp/metadata.go:508 +0x5f1
github.com/elastic/apm-data/input/otlp.TranslateTransaction.func1({0xc004fcc600, 0x1b}, {0xc0012a8e50?, 0xc0050564dc?})
        github.com/elastic/apm-data@v1.1.0/input/otlp/traces.go:290 +0x8be
go.opentelemetry.io/collector/pdata/pcommon.Map.Range({0xc0041ebaa0?, 0xc0050564dc?}, 0xc000b7a978)
        go.opentelemetry.io/collector/pdata@v1.5.0/pcommon/map.go:222 +0x97
```

## Notes

1. I do not see any proper way to log a message or propagate an error.
2. Therefore, deductively we are only left with dropping invalid array elements.
3. I prefer not to use `reflect`, but please comment if you think using `reflect` will be better and why.
4. Any ideas on Unit Testing?