### PR TITLE
Improve attribute handling

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -199,7 +199,7 @@ func (c *Consumer) convertLogRecord(
 			}
 			event.DataStream.Namespace = v.Str()
 		default:
-			setLabel(replaceDots(k), event, ifaceAttributeValue(v))
+			setLabel(replaceDots(k), event, v)
 		}
 		return true
 	})
@@ -239,7 +239,7 @@ func (c *Consumer) convertLogRecord(
 
 func setLabels(m pcommon.Map, event *modelpb.APMEvent) {
 	m.Range(func(k string, v pcommon.Value) bool {
-		setLabel(replaceDots(k), event, ifaceAttributeValue(v))
+		setLabel(replaceDots(k), event, v)
 		return true
 	})
 }

--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -139,7 +139,10 @@ func (c *Consumer) convertLogRecord(
 	if body := record.Body(); body.Type() != pcommon.ValueTypeEmpty {
 		event.Message = body.AsString()
 		if body.Type() == pcommon.ValueTypeMap {
-			setLabels(body.Map(), event)
+			body.Map().Range(func(k string, v pcommon.Value) bool {
+				setLabel(replaceDots(k), event, v)
+				return true
+			})
 		}
 	}
 	if traceID := record.TraceID(); !traceID.IsEmpty() {
@@ -235,11 +238,4 @@ func (c *Consumer) convertLogRecord(
 	}
 
 	return event
-}
-
-func setLabels(m pcommon.Map, event *modelpb.APMEvent) {
-	m.Range(func(k string, v pcommon.Value) bool {
-		setLabel(replaceDots(k), event, v)
-		return true
-	})
 }

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -185,7 +185,6 @@ func translateResourceMetadata(resource pcommon.Resource, out *modelpb.APMEvent)
 				out.Host = modelpb.HostFromVTPool()
 			}
 			out.Host.Architecture = truncate(v.Str())
-			// TODO: Don't think this is being tested.
 		case semconv.AttributeHostIP:
 			if out.Host == nil {
 				out.Host = modelpb.HostFromVTPool()
@@ -194,10 +193,9 @@ func translateResourceMetadata(resource pcommon.Resource, out *modelpb.APMEvent)
 			result := make([]*modelpb.IP, 0, slice.Len())
 			for i := 0; i < slice.Len(); i++ {
 				ip, err := modelpb.ParseIP(slice.At(i).Str())
-				if err != nil {
-					panic(err)
+				if err == nil {
+					result = append(result, ip)
 				}
-				result = append(result, ip)
 			}
 			out.Host.Ip = result
 
@@ -503,7 +501,7 @@ func setLabel(key string, event *modelpb.APMEvent, v pcommon.Value) {
 		modelpb.NumericLabels(event.NumericLabels).Set(key, v.Double())
 	case pcommon.ValueTypeSlice:
 		s := v.Slice()
-		if v.Slice().Len() == 0 {
+		if s.Len() == 0 {
 			return
 		}
 		switch s.At(0).Type() {

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -548,8 +548,6 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 		case float64:
 			value := make([]float64, 0, len(v))
 			for i := range v {
-				// Ensure that the array is homogeneous
-				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				if r, ok := v[i].(float64); ok {
 					value = append(value, r)
 				}

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -536,22 +536,22 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 		}
 		switch v[0].(type) {
 		case string:
-			value := make([]string, len(v))
+			value := make([]string, 0, len(v))
 			for i := range v {
 				// Ensure that the array is homogeneous
 				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				if r, ok := v[i].(string); ok {
-					value[i] = r
+					value = append(value, r)
 				}
 			}
 			modelpb.Labels(event.Labels).SetSlice(key, value)
 		case float64:
-			value := make([]float64, len(v))
+			value := make([]float64, 0, len(v))
 			for i := range v {
 				// Ensure that the array is homogeneous
 				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				if r, ok := v[i].(float64); ok {
-					value[i] = r
+					value = append(value, r)
 				}
 			}
 			modelpb.NumericLabels(event.NumericLabels).SetSlice(key, value)

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -539,11 +539,9 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 			value := make([]string, len(v))
 			for i := range v {
 				// Ensure that the array is homogeneous
-				switch r := v[i].(type) {
-				case string:
+				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
+				if r, ok := v[i].(string); ok {
 					value[i] = r
-				default:
-					// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				}
 			}
 			modelpb.Labels(event.Labels).SetSlice(key, value)
@@ -551,11 +549,9 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 			value := make([]float64, len(v))
 			for i := range v {
 				// Ensure that the array is homogeneous
-				switch r := v[i].(type) {
-				case float64:
+				// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
+				if r, ok := v[i].(float64); ok {
 					value[i] = r
-				default:
-					// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
 				}
 			}
 			modelpb.NumericLabels(event.NumericLabels).SetSlice(key, value)

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -538,13 +538,25 @@ func setLabel(key string, event *modelpb.APMEvent, v interface{}) {
 		case string:
 			value := make([]string, len(v))
 			for i := range v {
-				value[i] = v[i].(string)
+				// Ensure that the array is homogeneous
+				switch r := v[i].(type) {
+				case string:
+					value[i] = r
+				default:
+					// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
+				}
 			}
 			modelpb.Labels(event.Labels).SetSlice(key, value)
 		case float64:
 			value := make([]float64, len(v))
 			for i := range v {
-				value[i] = v[i].(float64)
+				// Ensure that the array is homogeneous
+				switch r := v[i].(type) {
+				case float64:
+					value[i] = r
+				default:
+					// Drop value that is not OTEL supported: https://opentelemetry.io/docs/specs/otel/common/
+				}
 			}
 			modelpb.NumericLabels(event.NumericLabels).SetSlice(key, value)
 		}

--- a/input/otlp/metadata_test.go
+++ b/input/otlp/metadata_test.go
@@ -447,7 +447,7 @@ func TestTranslateSpanSlice(t *testing.T) {
 			expectedLen: 0,
 		},
 		{
-			desc: "ensure nill array does not panic",
+			desc: "ensure nil array does not panic",
 			input: func() pcommon.Map {
 				m := pcommon.NewMap()
 				s := m.PutEmptySlice("k")
@@ -470,9 +470,7 @@ func TestTranslateSpanSlice(t *testing.T) {
 
 			labels := e.GetLabels()[key].GetValues()
 			numericals := e.GetNumericLabels()[key].GetValues()
-			length := len(labels) + len(numericals)
 
-			assert.Equal(t, tC.expectedLen, length)
 			assert.Equal(t, tC.expectedLabel, labels)
 			assert.Equal(t, tC.expectedNumericLabels, numericals)
 		})

--- a/input/otlp/metrics.go
+++ b/input/otlp/metrics.go
@@ -251,7 +251,7 @@ func (c *Consumer) handleScopeMetrics(
 					}
 					event.User.Name = truncate(v.Str())
 				default:
-					setLabel(k, event, ifaceAttributeValue(v))
+					setLabel(k, event, v)
 				}
 				return true
 			})

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -292,12 +292,12 @@ func TranslateTransaction(
 					}
 				}
 			default:
-				setLabel(k, event, ifaceAttributeValue(v))
+				setLabel(k, event, v)
 			}
 		case pcommon.ValueTypeBool:
-			setLabel(k, event, ifaceAttributeValue(v))
+			setLabel(k, event, v)
 		case pcommon.ValueTypeDouble:
-			setLabel(k, event, ifaceAttributeValue(v))
+			setLabel(k, event, v)
 		case pcommon.ValueTypeInt:
 			switch kDots {
 			case semconv.AttributeHTTPStatusCode, attributeHttpResponseStatusCode:
@@ -315,7 +315,7 @@ func TranslateTransaction(
 				isRPC = true
 				event.Transaction.Result = codes.Code(v.Int()).String()
 			default:
-				setLabel(k, event, ifaceAttributeValue(v))
+				setLabel(k, event, v)
 			}
 		case pcommon.ValueTypeMap:
 		case pcommon.ValueTypeStr:
@@ -491,7 +491,6 @@ func TranslateTransaction(
 					event.DataStream = modelpb.DataStreamFromVTPool()
 				}
 				event.DataStream.Namespace = stringval
-
 			default:
 				modelpb.Labels(event.Labels).Set(k, stringval)
 			}
@@ -644,17 +643,17 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 		k := replaceDots(kDots)
 		switch v.Type() {
 		case pcommon.ValueTypeSlice:
-			setLabel(k, event, ifaceAttributeValueSlice(v.Slice()))
+			setLabel(k, event, v)
 		case pcommon.ValueTypeBool:
 			switch kDots {
 			case semconv.AttributeMessagingTempDestination:
 				messageTempDestination = v.Bool()
 				fallthrough
 			default:
-				setLabel(k, event, strconv.FormatBool(v.Bool()))
+				setLabel(k, event, v)
 			}
 		case pcommon.ValueTypeDouble:
-			setLabel(k, event, v.Double())
+			setLabel(k, event, v)
 		case pcommon.ValueTypeInt:
 			switch kDots {
 			case "http.status_code", attributeHttpResponseStatusCode:
@@ -667,7 +666,7 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 				rpcSystem = "grpc"
 				isRPC = true
 			default:
-				setLabel(k, event, v.Int())
+				setLabel(k, event, v)
 			}
 		case pcommon.ValueTypeStr:
 			stringval := truncate(v.Str())
@@ -1116,7 +1115,7 @@ func (c *Consumer) convertSpanEvent(
 				event.DataStream.Namespace = v.Str()
 
 			default:
-				setLabel(replaceDots(k), event, ifaceAttributeValue(v))
+				setLabel(replaceDots(k), event, v)
 			}
 			return true
 		})
@@ -1161,7 +1160,7 @@ func (c *Consumer) convertSpanEvent(
 					event.Message = truncate(v.Str())
 					return true
 				}
-				setLabel(k, event, ifaceAttributeValue(v))
+				setLabel(k, event, v)
 			}
 			return true
 		})
@@ -1215,7 +1214,7 @@ func (c *Consumer) convertJaegerErrorSpanEvent(event ptrace.SpanEvent, apmEvent 
 			apmEvent.DataStream.Namespace = v.Str()
 
 		default:
-			setLabel(replaceDots(k), apmEvent, ifaceAttributeValue(v))
+			setLabel(replaceDots(k), apmEvent, v)
 		}
 		return true
 	})

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -294,10 +294,6 @@ func TranslateTransaction(
 			default:
 				setLabel(k, event, v)
 			}
-		case pcommon.ValueTypeBool:
-			setLabel(k, event, v)
-		case pcommon.ValueTypeDouble:
-			setLabel(k, event, v)
 		case pcommon.ValueTypeInt:
 			switch kDots {
 			case semconv.AttributeHTTPStatusCode, attributeHttpResponseStatusCode:
@@ -494,6 +490,8 @@ func TranslateTransaction(
 			default:
 				modelpb.Labels(event.Labels).Set(k, stringval)
 			}
+		default:
+			setLabel(k, event, v)
 		}
 		return true
 	})

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -642,8 +642,6 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 
 		k := replaceDots(kDots)
 		switch v.Type() {
-		case pcommon.ValueTypeSlice:
-			setLabel(k, event, v)
 		case pcommon.ValueTypeBool:
 			switch kDots {
 			case semconv.AttributeMessagingTempDestination:
@@ -652,8 +650,6 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 			default:
 				setLabel(k, event, v)
 			}
-		case pcommon.ValueTypeDouble:
-			setLabel(k, event, v)
 		case pcommon.ValueTypeInt:
 			switch kDots {
 			case "http.status_code", attributeHttpResponseStatusCode:
@@ -836,10 +832,11 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 					event.DataStream = modelpb.DataStreamFromVTPool()
 				}
 				event.DataStream.Namespace = stringval
-
 			default:
-				modelpb.Labels(event.Labels).Set(k, stringval)
+				setLabel(k, event, v)
 			}
+		default:
+			setLabel(k, event, v)
 		}
 		return true
 	})


### PR DESCRIPTION
Fix https://github.com/elastic/apm-server/issues/13703, with some refactoring of the conversion between OTLP attributes and APMEvent labels.

## Context

From my understanding looking at https://opentelemetry.io/docs/specs/otel/common/#attribute, the element values of an array attribute has to:

1. Only consist of primitive values which includes; `string`, `int64`, `bool`, and `float64`
2. All elements in this array has to be the same (homogeneous).

It can be deduced that nested arrays are not allowed, since if this would be the case, the spec would have to also allow pointers, or a struct type to be included as a primitive. Effectively, creating an array _reference_. An array as _value_ would not suffice, since its not atomic in principle. Rather, a collection, therefore breaking the homogeneous invariant. **So I highly doubt that Attribute array value are allowed to be nested.** 

From a practical point of view, the concept of an attribute is not hierarchical. So nesting doesn't really makes sense. Spans and traces can be nested. Attributes cannot.

## Problem

I've come to believe the reason for the bug in https://github.com/elastic/apm-server/issues/13703 is more fundamental to the way we convert between OTLP attributes and APMEvent labels, than simply dropping heterogeneous elements.

The func `ifaceAttributeValue` acts as an interface between conversion of a `pcommon.Value` and a Go primitive. However, this is done by using the `interface` construct in Go as an abstract _buffer_ for type conversion. 

This technique, though valid, in practice tends to force a developer's hand to introduce templating, as we see in the `pSliceToType` function. Which is a slippery slope into metaprogramming hell. This is a deadly trap in C++, and is why I'm personally not a big proponent of templates in Go.

The bigger problem with introducing `interface` as a buffer, is that at some point, we have to do the actual conversion from `any` (aka `interface`) to the real, concrete Go primitives. To my limited knowledge, this is what I understand the purpose of `setLabel` to be; a producer of Go primitives when the exact translation is not made explicit. Therefore, `setLabel` is mostly called in the `default` section or the `switch` statements in translation methods, like `translateResourceMetadata`, etc.

The problem with this is multifold:

1. **Testing:** It becomes very hard to test. You're left with converting between primitives multiple times to ensure you handle all the conversion edge cases.
2. **Information Loss:** Fundamentally, the reason for this difficult testing is due to information loss by introducing `interface`. For example, the concept of a `bool` in lost after `ifaceAttributeValue` is called.
3. **Stack:** `ifaceAttributeValue` is called recursively to ensure that all array elements are properly converted. This recursive call is needed if arrays can be nested, which I don't think they can. So you are left with unnecessary stack calls.
4. **Complexity:** All of this adds unnecessary code; extra testing, `interface`, templating, more functions than needed, and difficulty debugging. 

## Solution

Do the conversion between `pcommon.Value` and Go primitives directly (by only calling `setLabel`). Do not use `interface` or templating. Ignore a recursive solution. We are not working with a Tree or Graph data structure. Simply, a linear homogeneous array. 