### PR TITLE
feat: bump go to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/apm-data
 
-go 1.21.1
+go 1.22
 
 require (
 	github.com/elastic/opentelemetry-lib v0.8.1


### PR DESCRIPTION
Should unblock https://github.com/elastic/apm-data/pull/347

Bump to a supported version of go