### PR TITLE
ci: move jaeger to the otel dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       otel:
         patterns:
         - "go.opentelemetry.io/*"
-      jaeger:
-        patterns:
         - "github.com/jaegertracing/jaeger"
         - "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
       golang.org/x/:


### PR DESCRIPTION
jaeger is heavily using otel so raising two PRs often causes conflicts or double updates