### PR TITLE
Stop generating code for pooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,4 @@ install-protobuf:
 
 generate-modelpb: install-protobuf
 	./tools/generate-modelpb.sh
+	@$(MAKE) update-licenses fmt

--- a/input/elasticapm/internal/modeldecoder/modeldecoderutil/slice_test.go
+++ b/input/elasticapm/internal/modeldecoder/modeldecoderutil/slice_test.go
@@ -54,7 +54,7 @@ func TestResliceAndPopulateNil(t *testing.T) {
 	assert.Equal(t, downsize, len(s))
 
 	upsize := 21
-	s = ResliceAndPopulateNil(s, upsize, modelpb.APMEventFromVTPool)
+	s = ResliceAndPopulateNil(s, upsize, NewType[modelpb.APMEvent])
 	validateBackingArray(t, s, upsize)
 	assert.Equal(t, upsize, len(s))
 }

--- a/model/modelpb/agent_vtproto.pb.go
+++ b/model/modelpb/agent_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Agent) CloneVT() *Agent {
 	if m == nil {
 		return (*Agent)(nil)
 	}
-	r := AgentFromVTPool()
+	r := new(Agent)
 	r.Name = m.Name
 	r.Version = m.Version
 	r.EphemeralId = m.EphemeralId
@@ -119,26 +118,6 @@ func (m *Agent) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Agent = sync.Pool{
-	New: func() interface{} {
-		return &Agent{}
-	},
-}
-
-func (m *Agent) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Agent) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Agent.Put(m)
-	}
-}
-func AgentFromVTPool() *Agent {
-	return vtprotoPool_Agent.Get().(*Agent)
-}
 func (m *Agent) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/apmevent_vtproto.pb.go
+++ b/model/modelpb/apmevent_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *APMEvent) CloneVT() *APMEvent {
 	if m == nil {
 		return (*APMEvent)(nil)
 	}
-	r := APMEventFromVTPool()
+	r := new(APMEvent)
 	r.Timestamp = m.Timestamp
 	r.Span = m.Span.CloneVT()
 	r.Transaction = m.Transaction.CloneVT()
@@ -540,57 +539,6 @@ func (m *APMEvent) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_APMEvent = sync.Pool{
-	New: func() interface{} {
-		return &APMEvent{}
-	},
-}
-
-func (m *APMEvent) ResetVT() {
-	if m != nil {
-		m.Span.ReturnToVTPool()
-		m.Transaction.ReturnToVTPool()
-		m.Metricset.ReturnToVTPool()
-		m.Error.ReturnToVTPool()
-		m.Cloud.ReturnToVTPool()
-		m.Service.ReturnToVTPool()
-		m.Faas.ReturnToVTPool()
-		m.Network.ReturnToVTPool()
-		m.Container.ReturnToVTPool()
-		m.User.ReturnToVTPool()
-		m.Device.ReturnToVTPool()
-		m.Kubernetes.ReturnToVTPool()
-		m.Observer.ReturnToVTPool()
-		m.DataStream.ReturnToVTPool()
-		m.Agent.ReturnToVTPool()
-		m.Http.ReturnToVTPool()
-		m.UserAgent.ReturnToVTPool()
-		m.Trace.ReturnToVTPool()
-		m.Host.ReturnToVTPool()
-		m.Url.ReturnToVTPool()
-		m.Log.ReturnToVTPool()
-		m.Source.ReturnToVTPool()
-		m.Client.ReturnToVTPool()
-		f0 := m.ChildIds[:0]
-		m.Destination.ReturnToVTPool()
-		m.Session.ReturnToVTPool()
-		m.Process.ReturnToVTPool()
-		m.Event.ReturnToVTPool()
-		m.Code.ReturnToVTPool()
-		m.System.ReturnToVTPool()
-		m.Reset()
-		m.ChildIds = f0
-	}
-}
-func (m *APMEvent) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_APMEvent.Put(m)
-	}
-}
-func APMEventFromVTPool() *APMEvent {
-	return vtprotoPool_APMEvent.Get().(*APMEvent)
-}
 func (m *APMEvent) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -838,7 +786,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Span == nil {
-				m.Span = SpanFromVTPool()
+				m.Span = &Span{}
 			}
 			if err := m.Span.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1132,7 +1080,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Transaction == nil {
-				m.Transaction = TransactionFromVTPool()
+				m.Transaction = &Transaction{}
 			}
 			if err := m.Transaction.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1168,7 +1116,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Metricset == nil {
-				m.Metricset = MetricsetFromVTPool()
+				m.Metricset = &Metricset{}
 			}
 			if err := m.Metricset.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1204,7 +1152,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Error == nil {
-				m.Error = ErrorFromVTPool()
+				m.Error = &Error{}
 			}
 			if err := m.Error.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1240,7 +1188,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Cloud == nil {
-				m.Cloud = CloudFromVTPool()
+				m.Cloud = &Cloud{}
 			}
 			if err := m.Cloud.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1276,7 +1224,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Service == nil {
-				m.Service = ServiceFromVTPool()
+				m.Service = &Service{}
 			}
 			if err := m.Service.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1312,7 +1260,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Faas == nil {
-				m.Faas = FaasFromVTPool()
+				m.Faas = &Faas{}
 			}
 			if err := m.Faas.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1348,7 +1296,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Network == nil {
-				m.Network = NetworkFromVTPool()
+				m.Network = &Network{}
 			}
 			if err := m.Network.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1384,7 +1332,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Container == nil {
-				m.Container = ContainerFromVTPool()
+				m.Container = &Container{}
 			}
 			if err := m.Container.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1420,7 +1368,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.User == nil {
-				m.User = UserFromVTPool()
+				m.User = &User{}
 			}
 			if err := m.User.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1456,7 +1404,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Device == nil {
-				m.Device = DeviceFromVTPool()
+				m.Device = &Device{}
 			}
 			if err := m.Device.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1492,7 +1440,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Kubernetes == nil {
-				m.Kubernetes = KubernetesFromVTPool()
+				m.Kubernetes = &Kubernetes{}
 			}
 			if err := m.Kubernetes.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1528,7 +1476,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Observer == nil {
-				m.Observer = ObserverFromVTPool()
+				m.Observer = &Observer{}
 			}
 			if err := m.Observer.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1564,7 +1512,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.DataStream == nil {
-				m.DataStream = DataStreamFromVTPool()
+				m.DataStream = &DataStream{}
 			}
 			if err := m.DataStream.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1600,7 +1548,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Agent == nil {
-				m.Agent = AgentFromVTPool()
+				m.Agent = &Agent{}
 			}
 			if err := m.Agent.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1636,7 +1584,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Http == nil {
-				m.Http = HTTPFromVTPool()
+				m.Http = &HTTP{}
 			}
 			if err := m.Http.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1672,7 +1620,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.UserAgent == nil {
-				m.UserAgent = UserAgentFromVTPool()
+				m.UserAgent = &UserAgent{}
 			}
 			if err := m.UserAgent.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1772,7 +1720,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Trace == nil {
-				m.Trace = TraceFromVTPool()
+				m.Trace = &Trace{}
 			}
 			if err := m.Trace.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1808,7 +1756,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Host == nil {
-				m.Host = HostFromVTPool()
+				m.Host = &Host{}
 			}
 			if err := m.Host.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1844,7 +1792,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Url == nil {
-				m.Url = URLFromVTPool()
+				m.Url = &URL{}
 			}
 			if err := m.Url.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1880,7 +1828,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Log == nil {
-				m.Log = LogFromVTPool()
+				m.Log = &Log{}
 			}
 			if err := m.Log.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1916,7 +1864,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Source == nil {
-				m.Source = SourceFromVTPool()
+				m.Source = &Source{}
 			}
 			if err := m.Source.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1952,7 +1900,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Client == nil {
-				m.Client = ClientFromVTPool()
+				m.Client = &Client{}
 			}
 			if err := m.Client.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2020,7 +1968,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Destination == nil {
-				m.Destination = DestinationFromVTPool()
+				m.Destination = &Destination{}
 			}
 			if err := m.Destination.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2056,7 +2004,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Session == nil {
-				m.Session = SessionFromVTPool()
+				m.Session = &Session{}
 			}
 			if err := m.Session.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2092,7 +2040,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Process == nil {
-				m.Process = ProcessFromVTPool()
+				m.Process = &Process{}
 			}
 			if err := m.Process.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2128,7 +2076,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Event == nil {
-				m.Event = EventFromVTPool()
+				m.Event = &Event{}
 			}
 			if err := m.Event.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2164,7 +2112,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Code == nil {
-				m.Code = CodeFromVTPool()
+				m.Code = &Code{}
 			}
 			if err := m.Code.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -2200,7 +2148,7 @@ func (m *APMEvent) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.System == nil {
-				m.System = SystemFromVTPool()
+				m.System = &System{}
 			}
 			if err := m.System.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/client_vtproto.pb.go
+++ b/model/modelpb/client_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Client) CloneVT() *Client {
 	if m == nil {
 		return (*Client)(nil)
 	}
-	r := ClientFromVTPool()
+	r := new(Client)
 	r.Ip = m.Ip.CloneVT()
 	r.Domain = m.Domain
 	r.Port = m.Port
@@ -112,27 +111,6 @@ func (m *Client) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Client = sync.Pool{
-	New: func() interface{} {
-		return &Client{}
-	},
-}
-
-func (m *Client) ResetVT() {
-	if m != nil {
-		m.Ip.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *Client) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Client.Put(m)
-	}
-}
-func ClientFromVTPool() *Client {
-	return vtprotoPool_Client.Get().(*Client)
-}
 func (m *Client) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -213,7 +191,7 @@ func (m *Client) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Ip == nil {
-				m.Ip = IPFromVTPool()
+				m.Ip = &IP{}
 			}
 			if err := m.Ip.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/cloud_vtproto.pb.go
+++ b/model/modelpb/cloud_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Cloud) CloneVT() *Cloud {
 	if m == nil {
 		return (*Cloud)(nil)
 	}
-	r := CloudFromVTPool()
+	r := new(Cloud)
 	r.Origin = m.Origin.CloneVT()
 	r.AccountId = m.AccountId
 	r.AccountName = m.AccountName
@@ -70,7 +69,7 @@ func (m *CloudOrigin) CloneVT() *CloudOrigin {
 	if m == nil {
 		return (*CloudOrigin)(nil)
 	}
-	r := CloudOriginFromVTPool()
+	r := new(CloudOrigin)
 	r.AccountId = m.AccountId
 	r.Provider = m.Provider
 	r.Region = m.Region
@@ -267,48 +266,6 @@ func (m *CloudOrigin) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Cloud = sync.Pool{
-	New: func() interface{} {
-		return &Cloud{}
-	},
-}
-
-func (m *Cloud) ResetVT() {
-	if m != nil {
-		m.Origin.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *Cloud) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Cloud.Put(m)
-	}
-}
-func CloudFromVTPool() *Cloud {
-	return vtprotoPool_Cloud.Get().(*Cloud)
-}
-
-var vtprotoPool_CloudOrigin = sync.Pool{
-	New: func() interface{} {
-		return &CloudOrigin{}
-	},
-}
-
-func (m *CloudOrigin) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *CloudOrigin) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_CloudOrigin.Put(m)
-	}
-}
-func CloudOriginFromVTPool() *CloudOrigin {
-	return vtprotoPool_CloudOrigin.Get().(*CloudOrigin)
-}
 func (m *Cloud) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -452,7 +409,7 @@ func (m *Cloud) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Origin == nil {
-				m.Origin = CloudOriginFromVTPool()
+				m.Origin = &CloudOrigin{}
 			}
 			if err := m.Origin.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/code_vtproto.pb.go
+++ b/model/modelpb/code_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Code) CloneVT() *Code {
 	if m == nil {
 		return (*Code)(nil)
 	}
-	r := CodeFromVTPool()
+	r := new(Code)
 	r.Stacktrace = m.Stacktrace
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -95,26 +94,6 @@ func (m *Code) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Code = sync.Pool{
-	New: func() interface{} {
-		return &Code{}
-	},
-}
-
-func (m *Code) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Code) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Code.Put(m)
-	}
-}
-func CodeFromVTPool() *Code {
-	return vtprotoPool_Code.Get().(*Code)
-}
 func (m *Code) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/container_vtproto.pb.go
+++ b/model/modelpb/container_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Container) CloneVT() *Container {
 	if m == nil {
 		return (*Container)(nil)
 	}
-	r := ContainerFromVTPool()
+	r := new(Container)
 	r.Id = m.Id
 	r.Name = m.Name
 	r.Runtime = m.Runtime
@@ -127,26 +126,6 @@ func (m *Container) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Container = sync.Pool{
-	New: func() interface{} {
-		return &Container{}
-	},
-}
-
-func (m *Container) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Container) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Container.Put(m)
-	}
-}
-func ContainerFromVTPool() *Container {
-	return vtprotoPool_Container.Get().(*Container)
-}
 func (m *Container) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/datastream_vtproto.pb.go
+++ b/model/modelpb/datastream_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *DataStream) CloneVT() *DataStream {
 	if m == nil {
 		return (*DataStream)(nil)
 	}
-	r := DataStreamFromVTPool()
+	r := new(DataStream)
 	r.Type = m.Type
 	r.Dataset = m.Dataset
 	r.Namespace = m.Namespace
@@ -111,26 +110,6 @@ func (m *DataStream) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_DataStream = sync.Pool{
-	New: func() interface{} {
-		return &DataStream{}
-	},
-}
-
-func (m *DataStream) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *DataStream) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_DataStream.Put(m)
-	}
-}
-func DataStreamFromVTPool() *DataStream {
-	return vtprotoPool_DataStream.Get().(*DataStream)
-}
 func (m *DataStream) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/destination_vtproto.pb.go
+++ b/model/modelpb/destination_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Destination) CloneVT() *Destination {
 	if m == nil {
 		return (*Destination)(nil)
 	}
-	r := DestinationFromVTPool()
+	r := new(Destination)
 	r.Address = m.Address
 	r.Port = m.Port
 	if len(m.unknownFields) > 0 {
@@ -101,26 +100,6 @@ func (m *Destination) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Destination = sync.Pool{
-	New: func() interface{} {
-		return &Destination{}
-	},
-}
-
-func (m *Destination) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Destination) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Destination.Put(m)
-	}
-}
-func DestinationFromVTPool() *Destination {
-	return vtprotoPool_Destination.Get().(*Destination)
-}
 func (m *Destination) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/device_vtproto.pb.go
+++ b/model/modelpb/device_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Device) CloneVT() *Device {
 	if m == nil {
 		return (*Device)(nil)
 	}
-	r := DeviceFromVTPool()
+	r := new(Device)
 	r.Id = m.Id
 	r.Model = m.Model.CloneVT()
 	r.Manufacturer = m.Manufacturer
@@ -61,7 +60,7 @@ func (m *DeviceModel) CloneVT() *DeviceModel {
 	if m == nil {
 		return (*DeviceModel)(nil)
 	}
-	r := DeviceModelFromVTPool()
+	r := new(DeviceModel)
 	r.Name = m.Name
 	r.Identifier = m.Identifier
 	if len(m.unknownFields) > 0 {
@@ -179,48 +178,6 @@ func (m *DeviceModel) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Device = sync.Pool{
-	New: func() interface{} {
-		return &Device{}
-	},
-}
-
-func (m *Device) ResetVT() {
-	if m != nil {
-		m.Model.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *Device) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Device.Put(m)
-	}
-}
-func DeviceFromVTPool() *Device {
-	return vtprotoPool_Device.Get().(*Device)
-}
-
-var vtprotoPool_DeviceModel = sync.Pool{
-	New: func() interface{} {
-		return &DeviceModel{}
-	},
-}
-
-func (m *DeviceModel) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *DeviceModel) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_DeviceModel.Put(m)
-	}
-}
-func DeviceModelFromVTPool() *DeviceModel {
-	return vtprotoPool_DeviceModel.Get().(*DeviceModel)
-}
 func (m *Device) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -352,7 +309,7 @@ func (m *Device) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Model == nil {
-				m.Model = DeviceModelFromVTPool()
+				m.Model = &DeviceModel{}
 			}
 			if err := m.Model.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/error_vtproto.pb.go
+++ b/model/modelpb/error_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Error) CloneVT() *Error {
 	if m == nil {
 		return (*Error)(nil)
 	}
-	r := ErrorFromVTPool()
+	r := new(Error)
 	r.Exception = m.Exception.CloneVT()
 	r.Log = m.Log.CloneVT()
 	r.Id = m.Id
@@ -73,7 +72,7 @@ func (m *Exception) CloneVT() *Exception {
 	if m == nil {
 		return (*Exception)(nil)
 	}
-	r := ExceptionFromVTPool()
+	r := new(Exception)
 	r.Message = m.Message
 	r.Module = m.Module
 	r.Code = m.Code
@@ -118,7 +117,7 @@ func (m *ErrorLog) CloneVT() *ErrorLog {
 	if m == nil {
 		return (*ErrorLog)(nil)
 	}
-	r := ErrorLogFromVTPool()
+	r := new(ErrorLog)
 	r.Message = m.Message
 	r.Level = m.Level
 	r.ParamMessage = m.ParamMessage
@@ -428,95 +427,6 @@ func (m *ErrorLog) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Error = sync.Pool{
-	New: func() interface{} {
-		return &Error{}
-	},
-}
-
-func (m *Error) ResetVT() {
-	if m != nil {
-		for _, mm := range m.Custom {
-			mm.ResetVT()
-		}
-		f0 := m.Custom[:0]
-		m.Exception.ReturnToVTPool()
-		m.Log.ReturnToVTPool()
-		m.Reset()
-		m.Custom = f0
-	}
-}
-func (m *Error) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Error.Put(m)
-	}
-}
-func ErrorFromVTPool() *Error {
-	return vtprotoPool_Error.Get().(*Error)
-}
-
-var vtprotoPool_Exception = sync.Pool{
-	New: func() interface{} {
-		return &Exception{}
-	},
-}
-
-func (m *Exception) ResetVT() {
-	if m != nil {
-		for _, mm := range m.Attributes {
-			mm.ResetVT()
-		}
-		f0 := m.Attributes[:0]
-		for _, mm := range m.Stacktrace {
-			mm.ResetVT()
-		}
-		f1 := m.Stacktrace[:0]
-		for _, mm := range m.Cause {
-			mm.ResetVT()
-		}
-		f2 := m.Cause[:0]
-		m.Reset()
-		m.Attributes = f0
-		m.Stacktrace = f1
-		m.Cause = f2
-	}
-}
-func (m *Exception) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Exception.Put(m)
-	}
-}
-func ExceptionFromVTPool() *Exception {
-	return vtprotoPool_Exception.Get().(*Exception)
-}
-
-var vtprotoPool_ErrorLog = sync.Pool{
-	New: func() interface{} {
-		return &ErrorLog{}
-	},
-}
-
-func (m *ErrorLog) ResetVT() {
-	if m != nil {
-		for _, mm := range m.Stacktrace {
-			mm.ResetVT()
-		}
-		f0 := m.Stacktrace[:0]
-		m.Reset()
-		m.Stacktrace = f0
-	}
-}
-func (m *ErrorLog) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_ErrorLog.Put(m)
-	}
-}
-func ErrorLogFromVTPool() *ErrorLog {
-	return vtprotoPool_ErrorLog.Get().(*ErrorLog)
-}
 func (m *Error) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -702,14 +612,7 @@ func (m *Error) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Custom) == cap(m.Custom) {
-				m.Custom = append(m.Custom, &KeyValue{})
-			} else {
-				m.Custom = m.Custom[:len(m.Custom)+1]
-				if m.Custom[len(m.Custom)-1] == nil {
-					m.Custom[len(m.Custom)-1] = &KeyValue{}
-				}
-			}
+			m.Custom = append(m.Custom, &KeyValue{})
 			if err := m.Custom[len(m.Custom)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -744,7 +647,7 @@ func (m *Error) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Exception == nil {
-				m.Exception = ExceptionFromVTPool()
+				m.Exception = &Exception{}
 			}
 			if err := m.Exception.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -780,7 +683,7 @@ func (m *Error) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Log == nil {
-				m.Log = ErrorLogFromVTPool()
+				m.Log = &ErrorLog{}
 			}
 			if err := m.Log.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1154,14 +1057,7 @@ func (m *Exception) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Attributes) == cap(m.Attributes) {
-				m.Attributes = append(m.Attributes, &KeyValue{})
-			} else {
-				m.Attributes = m.Attributes[:len(m.Attributes)+1]
-				if m.Attributes[len(m.Attributes)-1] == nil {
-					m.Attributes[len(m.Attributes)-1] = &KeyValue{}
-				}
-			}
+			m.Attributes = append(m.Attributes, &KeyValue{})
 			if err := m.Attributes[len(m.Attributes)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1195,14 +1091,7 @@ func (m *Exception) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Stacktrace) == cap(m.Stacktrace) {
-				m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
-			} else {
-				m.Stacktrace = m.Stacktrace[:len(m.Stacktrace)+1]
-				if m.Stacktrace[len(m.Stacktrace)-1] == nil {
-					m.Stacktrace[len(m.Stacktrace)-1] = &StacktraceFrame{}
-				}
-			}
+			m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
 			if err := m.Stacktrace[len(m.Stacktrace)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1289,14 +1178,7 @@ func (m *Exception) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Cause) == cap(m.Cause) {
-				m.Cause = append(m.Cause, &Exception{})
-			} else {
-				m.Cause = m.Cause[:len(m.Cause)+1]
-				if m.Cause[len(m.Cause)-1] == nil {
-					m.Cause[len(m.Cause)-1] = &Exception{}
-				}
-			}
+			m.Cause = append(m.Cause, &Exception{})
 			if err := m.Cause[len(m.Cause)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1509,14 +1391,7 @@ func (m *ErrorLog) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Stacktrace) == cap(m.Stacktrace) {
-				m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
-			} else {
-				m.Stacktrace = m.Stacktrace[:len(m.Stacktrace)+1]
-				if m.Stacktrace[len(m.Stacktrace)-1] == nil {
-					m.Stacktrace[len(m.Stacktrace)-1] = &StacktraceFrame{}
-				}
-			}
+			m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
 			if err := m.Stacktrace[len(m.Stacktrace)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/model/modelpb/event_vtproto.pb.go
+++ b/model/modelpb/event_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Event) CloneVT() *Event {
 	if m == nil {
 		return (*Event)(nil)
 	}
-	r := EventFromVTPool()
+	r := new(Event)
 	r.Outcome = m.Outcome
 	r.Action = m.Action
 	r.Dataset = m.Dataset
@@ -172,27 +171,6 @@ func (m *Event) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Event = sync.Pool{
-	New: func() interface{} {
-		return &Event{}
-	},
-}
-
-func (m *Event) ResetVT() {
-	if m != nil {
-		m.SuccessCount.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *Event) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Event.Put(m)
-	}
-}
-func EventFromVTPool() *Event {
-	return vtprotoPool_Event.Get().(*Event)
-}
 func (m *Event) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -495,7 +473,7 @@ func (m *Event) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.SuccessCount == nil {
-				m.SuccessCount = SummaryMetricFromVTPool()
+				m.SuccessCount = &SummaryMetric{}
 			}
 			if err := m.SuccessCount.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/experience_vtproto.pb.go
+++ b/model/modelpb/experience_vtproto.pb.go
@@ -26,7 +26,6 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -44,7 +43,7 @@ func (m *UserExperience) CloneVT() *UserExperience {
 	if m == nil {
 		return (*UserExperience)(nil)
 	}
-	r := UserExperienceFromVTPool()
+	r := new(UserExperience)
 	r.CumulativeLayoutShift = m.CumulativeLayoutShift
 	r.FirstInputDelay = m.FirstInputDelay
 	r.TotalBlockingTime = m.TotalBlockingTime
@@ -64,7 +63,7 @@ func (m *LongtaskMetrics) CloneVT() *LongtaskMetrics {
 	if m == nil {
 		return (*LongtaskMetrics)(nil)
 	}
-	r := LongtaskMetricsFromVTPool()
+	r := new(LongtaskMetrics)
 	r.Count = m.Count
 	r.Sum = m.Sum
 	r.Max = m.Max
@@ -190,48 +189,6 @@ func (m *LongtaskMetrics) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_UserExperience = sync.Pool{
-	New: func() interface{} {
-		return &UserExperience{}
-	},
-}
-
-func (m *UserExperience) ResetVT() {
-	if m != nil {
-		m.LongTask.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *UserExperience) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_UserExperience.Put(m)
-	}
-}
-func UserExperienceFromVTPool() *UserExperience {
-	return vtprotoPool_UserExperience.Get().(*UserExperience)
-}
-
-var vtprotoPool_LongtaskMetrics = sync.Pool{
-	New: func() interface{} {
-		return &LongtaskMetrics{}
-	},
-}
-
-func (m *LongtaskMetrics) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *LongtaskMetrics) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_LongtaskMetrics.Put(m)
-	}
-}
-func LongtaskMetricsFromVTPool() *LongtaskMetrics {
-	return vtprotoPool_LongtaskMetrics.Get().(*LongtaskMetrics)
-}
 func (m *UserExperience) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -366,7 +323,7 @@ func (m *UserExperience) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.LongTask == nil {
-				m.LongTask = LongtaskMetricsFromVTPool()
+				m.LongTask = &LongtaskMetrics{}
 			}
 			if err := m.LongTask.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/faas_vtproto.pb.go
+++ b/model/modelpb/faas_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Faas) CloneVT() *Faas {
 	if m == nil {
 		return (*Faas)(nil)
 	}
-	r := FaasFromVTPool()
+	r := new(Faas)
 	r.Id = m.Id
 	r.Execution = m.Execution
 	r.TriggerType = m.TriggerType
@@ -149,26 +148,6 @@ func (m *Faas) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Faas = sync.Pool{
-	New: func() interface{} {
-		return &Faas{}
-	},
-}
-
-func (m *Faas) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Faas) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Faas.Put(m)
-	}
-}
-func FaasFromVTPool() *Faas {
-	return vtprotoPool_Faas.Get().(*Faas)
-}
 func (m *Faas) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/headers_vtproto.pb.go
+++ b/model/modelpb/headers_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *HTTPHeader) CloneVT() *HTTPHeader {
 	if m == nil {
 		return (*HTTPHeader)(nil)
 	}
-	r := HTTPHeaderFromVTPool()
+	r := new(HTTPHeader)
 	r.Key = m.Key
 	if rhs := m.Value; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
@@ -109,28 +108,6 @@ func (m *HTTPHeader) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_HTTPHeader = sync.Pool{
-	New: func() interface{} {
-		return &HTTPHeader{}
-	},
-}
-
-func (m *HTTPHeader) ResetVT() {
-	if m != nil {
-		f0 := m.Value[:0]
-		m.Reset()
-		m.Value = f0
-	}
-}
-func (m *HTTPHeader) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_HTTPHeader.Put(m)
-	}
-}
-func HTTPHeaderFromVTPool() *HTTPHeader {
-	return vtprotoPool_HTTPHeader.Get().(*HTTPHeader)
-}
 func (m *HTTPHeader) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/host_vtproto.pb.go
+++ b/model/modelpb/host_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Host) CloneVT() *Host {
 	if m == nil {
 		return (*Host)(nil)
 	}
-	r := HostFromVTPool()
+	r := new(Host)
 	r.Os = m.Os.CloneVT()
 	r.Hostname = m.Hostname
 	r.Name = m.Name
@@ -157,32 +156,6 @@ func (m *Host) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Host = sync.Pool{
-	New: func() interface{} {
-		return &Host{}
-	},
-}
-
-func (m *Host) ResetVT() {
-	if m != nil {
-		m.Os.ReturnToVTPool()
-		for _, mm := range m.Ip {
-			mm.ResetVT()
-		}
-		f0 := m.Ip[:0]
-		m.Reset()
-		m.Ip = f0
-	}
-}
-func (m *Host) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Host.Put(m)
-	}
-}
-func HostFromVTPool() *Host {
-	return vtprotoPool_Host.Get().(*Host)
-}
 func (m *Host) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -282,7 +255,7 @@ func (m *Host) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Os == nil {
-				m.Os = OSFromVTPool()
+				m.Os = &OS{}
 			}
 			if err := m.Os.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -477,14 +450,7 @@ func (m *Host) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Ip) == cap(m.Ip) {
-				m.Ip = append(m.Ip, &IP{})
-			} else {
-				m.Ip = m.Ip[:len(m.Ip)+1]
-				if m.Ip[len(m.Ip)-1] == nil {
-					m.Ip[len(m.Ip)-1] = &IP{}
-				}
-			}
+			m.Ip = append(m.Ip, &IP{})
 			if err := m.Ip[len(m.Ip)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/model/modelpb/http_vtproto.pb.go
+++ b/model/modelpb/http_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	structpb1 "github.com/planetscale/vtprotobuf/types/known/structpb"
@@ -44,7 +43,7 @@ func (m *HTTP) CloneVT() *HTTP {
 	if m == nil {
 		return (*HTTP)(nil)
 	}
-	r := HTTPFromVTPool()
+	r := new(HTTP)
 	r.Request = m.Request.CloneVT()
 	r.Response = m.Response.CloneVT()
 	r.Version = m.Version
@@ -63,7 +62,7 @@ func (m *HTTPRequest) CloneVT() *HTTPRequest {
 	if m == nil {
 		return (*HTTPRequest)(nil)
 	}
-	r := HTTPRequestFromVTPool()
+	r := new(HTTPRequest)
 	r.Body = (*structpb.Value)((*structpb1.Value)(m.Body).CloneVT())
 	r.Id = m.Id
 	r.Method = m.Method
@@ -104,7 +103,7 @@ func (m *HTTPResponse) CloneVT() *HTTPResponse {
 	if m == nil {
 		return (*HTTPResponse)(nil)
 	}
-	r := HTTPResponseFromVTPool()
+	r := new(HTTPResponse)
 	r.StatusCode = m.StatusCode
 	if rhs := m.Headers; rhs != nil {
 		tmpContainer := make([]*HTTPHeader, len(rhs))
@@ -389,90 +388,6 @@ func (m *HTTPResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_HTTP = sync.Pool{
-	New: func() interface{} {
-		return &HTTP{}
-	},
-}
-
-func (m *HTTP) ResetVT() {
-	if m != nil {
-		m.Request.ReturnToVTPool()
-		m.Response.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *HTTP) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_HTTP.Put(m)
-	}
-}
-func HTTPFromVTPool() *HTTP {
-	return vtprotoPool_HTTP.Get().(*HTTP)
-}
-
-var vtprotoPool_HTTPRequest = sync.Pool{
-	New: func() interface{} {
-		return &HTTPRequest{}
-	},
-}
-
-func (m *HTTPRequest) ResetVT() {
-	if m != nil {
-		for _, mm := range m.Headers {
-			mm.ResetVT()
-		}
-		f0 := m.Headers[:0]
-		for _, mm := range m.Env {
-			mm.ResetVT()
-		}
-		f1 := m.Env[:0]
-		for _, mm := range m.Cookies {
-			mm.ResetVT()
-		}
-		f2 := m.Cookies[:0]
-		m.Reset()
-		m.Headers = f0
-		m.Env = f1
-		m.Cookies = f2
-	}
-}
-func (m *HTTPRequest) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_HTTPRequest.Put(m)
-	}
-}
-func HTTPRequestFromVTPool() *HTTPRequest {
-	return vtprotoPool_HTTPRequest.Get().(*HTTPRequest)
-}
-
-var vtprotoPool_HTTPResponse = sync.Pool{
-	New: func() interface{} {
-		return &HTTPResponse{}
-	},
-}
-
-func (m *HTTPResponse) ResetVT() {
-	if m != nil {
-		for _, mm := range m.Headers {
-			mm.ResetVT()
-		}
-		f0 := m.Headers[:0]
-		m.Reset()
-		m.Headers = f0
-	}
-}
-func (m *HTTPResponse) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_HTTPResponse.Put(m)
-	}
-}
-func HTTPResponseFromVTPool() *HTTPResponse {
-	return vtprotoPool_HTTPResponse.Get().(*HTTPResponse)
-}
 func (m *HTTP) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -632,7 +547,7 @@ func (m *HTTP) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Request == nil {
-				m.Request = HTTPRequestFromVTPool()
+				m.Request = &HTTPRequest{}
 			}
 			if err := m.Request.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -668,7 +583,7 @@ func (m *HTTP) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Response == nil {
-				m.Response = HTTPResponseFromVTPool()
+				m.Response = &HTTPResponse{}
 			}
 			if err := m.Response.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -822,14 +737,7 @@ func (m *HTTPRequest) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Headers) == cap(m.Headers) {
-				m.Headers = append(m.Headers, &HTTPHeader{})
-			} else {
-				m.Headers = m.Headers[:len(m.Headers)+1]
-				if m.Headers[len(m.Headers)-1] == nil {
-					m.Headers[len(m.Headers)-1] = &HTTPHeader{}
-				}
-			}
+			m.Headers = append(m.Headers, &HTTPHeader{})
 			if err := m.Headers[len(m.Headers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -863,14 +771,7 @@ func (m *HTTPRequest) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Env) == cap(m.Env) {
-				m.Env = append(m.Env, &KeyValue{})
-			} else {
-				m.Env = m.Env[:len(m.Env)+1]
-				if m.Env[len(m.Env)-1] == nil {
-					m.Env[len(m.Env)-1] = &KeyValue{}
-				}
-			}
+			m.Env = append(m.Env, &KeyValue{})
 			if err := m.Env[len(m.Env)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -904,14 +805,7 @@ func (m *HTTPRequest) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Cookies) == cap(m.Cookies) {
-				m.Cookies = append(m.Cookies, &KeyValue{})
-			} else {
-				m.Cookies = m.Cookies[:len(m.Cookies)+1]
-				if m.Cookies[len(m.Cookies)-1] == nil {
-					m.Cookies[len(m.Cookies)-1] = &KeyValue{}
-				}
-			}
+			m.Cookies = append(m.Cookies, &KeyValue{})
 			if err := m.Cookies[len(m.Cookies)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1092,14 +986,7 @@ func (m *HTTPResponse) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Headers) == cap(m.Headers) {
-				m.Headers = append(m.Headers, &HTTPHeader{})
-			} else {
-				m.Headers = m.Headers[:len(m.Headers)+1]
-				if m.Headers[len(m.Headers)-1] == nil {
-					m.Headers[len(m.Headers)-1] = &HTTPHeader{}
-				}
-			}
+			m.Headers = append(m.Headers, &HTTPHeader{})
 			if err := m.Headers[len(m.Headers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/model/modelpb/ip_vtproto.pb.go
+++ b/model/modelpb/ip_vtproto.pb.go
@@ -25,7 +25,6 @@ import (
 	binary "encoding/binary"
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -43,7 +42,7 @@ func (m *IP) CloneVT() *IP {
 	if m == nil {
 		return (*IP)(nil)
 	}
-	r := IPFromVTPool()
+	r := new(IP)
 	r.V4 = m.V4
 	if rhs := m.V6; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
@@ -107,28 +106,6 @@ func (m *IP) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_IP = sync.Pool{
-	New: func() interface{} {
-		return &IP{}
-	},
-}
-
-func (m *IP) ResetVT() {
-	if m != nil {
-		f0 := m.V6[:0]
-		m.Reset()
-		m.V6 = f0
-	}
-}
-func (m *IP) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_IP.Put(m)
-	}
-}
-func IPFromVTPool() *IP {
-	return vtprotoPool_IP.Get().(*IP)
-}
 func (m *IP) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/keyvalue_vtproto.pb.go
+++ b/model/modelpb/keyvalue_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	structpb1 "github.com/planetscale/vtprotobuf/types/known/structpb"
@@ -44,7 +43,7 @@ func (m *KeyValue) CloneVT() *KeyValue {
 	if m == nil {
 		return (*KeyValue)(nil)
 	}
-	r := KeyValueFromVTPool()
+	r := new(KeyValue)
 	r.Key = m.Key
 	r.Value = (*structpb.Value)((*structpb1.Value)(m.Value).CloneVT())
 	if len(m.unknownFields) > 0 {
@@ -108,26 +107,6 @@ func (m *KeyValue) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_KeyValue = sync.Pool{
-	New: func() interface{} {
-		return &KeyValue{}
-	},
-}
-
-func (m *KeyValue) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *KeyValue) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_KeyValue.Put(m)
-	}
-}
-func KeyValueFromVTPool() *KeyValue {
-	return vtprotoPool_KeyValue.Get().(*KeyValue)
-}
 func (m *KeyValue) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/kubernetes_vtproto.pb.go
+++ b/model/modelpb/kubernetes_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Kubernetes) CloneVT() *Kubernetes {
 	if m == nil {
 		return (*Kubernetes)(nil)
 	}
-	r := KubernetesFromVTPool()
+	r := new(Kubernetes)
 	r.Namespace = m.Namespace
 	r.NodeName = m.NodeName
 	r.PodName = m.PodName
@@ -119,26 +118,6 @@ func (m *Kubernetes) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Kubernetes = sync.Pool{
-	New: func() interface{} {
-		return &Kubernetes{}
-	},
-}
-
-func (m *Kubernetes) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Kubernetes) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Kubernetes.Put(m)
-	}
-}
-func KubernetesFromVTPool() *Kubernetes {
-	return vtprotoPool_Kubernetes.Get().(*Kubernetes)
-}
 func (m *Kubernetes) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/labels_vtproto.pb.go
+++ b/model/modelpb/labels_vtproto.pb.go
@@ -26,7 +26,6 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -44,7 +43,7 @@ func (m *LabelValue) CloneVT() *LabelValue {
 	if m == nil {
 		return (*LabelValue)(nil)
 	}
-	r := LabelValueFromVTPool()
+	r := new(LabelValue)
 	r.Value = m.Value
 	r.Global = m.Global
 	if rhs := m.Values; rhs != nil {
@@ -67,7 +66,7 @@ func (m *NumericLabelValue) CloneVT() *NumericLabelValue {
 	if m == nil {
 		return (*NumericLabelValue)(nil)
 	}
-	r := NumericLabelValueFromVTPool()
+	r := new(NumericLabelValue)
 	r.Value = m.Value
 	r.Global = m.Global
 	if rhs := m.Values; rhs != nil {
@@ -204,51 +203,6 @@ func (m *NumericLabelValue) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_LabelValue = sync.Pool{
-	New: func() interface{} {
-		return &LabelValue{}
-	},
-}
-
-func (m *LabelValue) ResetVT() {
-	if m != nil {
-		f0 := m.Values[:0]
-		m.Reset()
-		m.Values = f0
-	}
-}
-func (m *LabelValue) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_LabelValue.Put(m)
-	}
-}
-func LabelValueFromVTPool() *LabelValue {
-	return vtprotoPool_LabelValue.Get().(*LabelValue)
-}
-
-var vtprotoPool_NumericLabelValue = sync.Pool{
-	New: func() interface{} {
-		return &NumericLabelValue{}
-	},
-}
-
-func (m *NumericLabelValue) ResetVT() {
-	if m != nil {
-		f0 := m.Values[:0]
-		m.Reset()
-		m.Values = f0
-	}
-}
-func (m *NumericLabelValue) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_NumericLabelValue.Put(m)
-	}
-}
-func NumericLabelValueFromVTPool() *NumericLabelValue {
-	return vtprotoPool_NumericLabelValue.Get().(*NumericLabelValue)
-}
 func (m *LabelValue) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -493,7 +447,7 @@ func (m *NumericLabelValue) UnmarshalVT(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Values) == 0 && cap(m.Values) < elementCount {
+				if elementCount != 0 && len(m.Values) == 0 {
 					m.Values = make([]float64, 0, elementCount)
 				}
 				for iNdEx < postIndex {

--- a/model/modelpb/log_vtproto.pb.go
+++ b/model/modelpb/log_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Log) CloneVT() *Log {
 	if m == nil {
 		return (*Log)(nil)
 	}
-	r := LogFromVTPool()
+	r := new(Log)
 	r.Level = m.Level
 	r.Logger = m.Logger
 	r.Origin = m.Origin.CloneVT()
@@ -61,7 +60,7 @@ func (m *LogOrigin) CloneVT() *LogOrigin {
 	if m == nil {
 		return (*LogOrigin)(nil)
 	}
-	r := LogOriginFromVTPool()
+	r := new(LogOrigin)
 	r.FunctionName = m.FunctionName
 	r.File = m.File.CloneVT()
 	if len(m.unknownFields) > 0 {
@@ -79,7 +78,7 @@ func (m *LogOriginFile) CloneVT() *LogOriginFile {
 	if m == nil {
 		return (*LogOriginFile)(nil)
 	}
-	r := LogOriginFileFromVTPool()
+	r := new(LogOriginFile)
 	r.Name = m.Name
 	r.Line = m.Line
 	if len(m.unknownFields) > 0 {
@@ -245,70 +244,6 @@ func (m *LogOriginFile) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Log = sync.Pool{
-	New: func() interface{} {
-		return &Log{}
-	},
-}
-
-func (m *Log) ResetVT() {
-	if m != nil {
-		m.Origin.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *Log) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Log.Put(m)
-	}
-}
-func LogFromVTPool() *Log {
-	return vtprotoPool_Log.Get().(*Log)
-}
-
-var vtprotoPool_LogOrigin = sync.Pool{
-	New: func() interface{} {
-		return &LogOrigin{}
-	},
-}
-
-func (m *LogOrigin) ResetVT() {
-	if m != nil {
-		m.File.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *LogOrigin) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_LogOrigin.Put(m)
-	}
-}
-func LogOriginFromVTPool() *LogOrigin {
-	return vtprotoPool_LogOrigin.Get().(*LogOrigin)
-}
-
-var vtprotoPool_LogOriginFile = sync.Pool{
-	New: func() interface{} {
-		return &LogOriginFile{}
-	},
-}
-
-func (m *LogOriginFile) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *LogOriginFile) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_LogOriginFile.Put(m)
-	}
-}
-func LogOriginFileFromVTPool() *LogOriginFile {
-	return vtprotoPool_LogOriginFile.Get().(*LogOriginFile)
-}
 func (m *Log) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -489,7 +424,7 @@ func (m *Log) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Origin == nil {
-				m.Origin = LogOriginFromVTPool()
+				m.Origin = &LogOrigin{}
 			}
 			if err := m.Origin.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -608,7 +543,7 @@ func (m *LogOrigin) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.File == nil {
-				m.File = LogOriginFileFromVTPool()
+				m.File = &LogOriginFile{}
 			}
 			if err := m.File.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/message_vtproto.pb.go
+++ b/model/modelpb/message_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Message) CloneVT() *Message {
 	if m == nil {
 		return (*Message)(nil)
 	}
-	r := MessageFromVTPool()
+	r := new(Message)
 	r.Body = m.Body
 	r.QueueName = m.QueueName
 	r.RoutingKey = m.RoutingKey
@@ -139,31 +138,6 @@ func (m *Message) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Message = sync.Pool{
-	New: func() interface{} {
-		return &Message{}
-	},
-}
-
-func (m *Message) ResetVT() {
-	if m != nil {
-		for _, mm := range m.Headers {
-			mm.ResetVT()
-		}
-		f0 := m.Headers[:0]
-		m.Reset()
-		m.Headers = f0
-	}
-}
-func (m *Message) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Message.Put(m)
-	}
-}
-func MessageFromVTPool() *Message {
-	return vtprotoPool_Message.Get().(*Message)
-}
 func (m *Message) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -285,14 +259,7 @@ func (m *Message) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Headers) == cap(m.Headers) {
-				m.Headers = append(m.Headers, &HTTPHeader{})
-			} else {
-				m.Headers = m.Headers[:len(m.Headers)+1]
-				if m.Headers[len(m.Headers)-1] == nil {
-					m.Headers[len(m.Headers)-1] = &HTTPHeader{}
-				}
-			}
+			m.Headers = append(m.Headers, &HTTPHeader{})
 			if err := m.Headers[len(m.Headers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/model/modelpb/metricset_vtproto.pb.go
+++ b/model/modelpb/metricset_vtproto.pb.go
@@ -26,7 +26,6 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -44,7 +43,7 @@ func (m *Metricset) CloneVT() *Metricset {
 	if m == nil {
 		return (*Metricset)(nil)
 	}
-	r := MetricsetFromVTPool()
+	r := new(Metricset)
 	r.Name = m.Name
 	r.Interval = m.Interval
 	r.DocCount = m.DocCount
@@ -70,7 +69,7 @@ func (m *MetricsetSample) CloneVT() *MetricsetSample {
 	if m == nil {
 		return (*MetricsetSample)(nil)
 	}
-	r := MetricsetSampleFromVTPool()
+	r := new(MetricsetSample)
 	r.Type = m.Type
 	r.Name = m.Name
 	r.Unit = m.Unit
@@ -92,7 +91,7 @@ func (m *Histogram) CloneVT() *Histogram {
 	if m == nil {
 		return (*Histogram)(nil)
 	}
-	r := HistogramFromVTPool()
+	r := new(Histogram)
 	if rhs := m.Values; rhs != nil {
 		tmpContainer := make([]float64, len(rhs))
 		copy(tmpContainer, rhs)
@@ -118,7 +117,7 @@ func (m *SummaryMetric) CloneVT() *SummaryMetric {
 	if m == nil {
 		return (*SummaryMetric)(nil)
 	}
-	r := SummaryMetricFromVTPool()
+	r := new(SummaryMetric)
 	r.Count = m.Count
 	r.Sum = m.Sum
 	if len(m.unknownFields) > 0 {
@@ -136,7 +135,7 @@ func (m *AggregatedDuration) CloneVT() *AggregatedDuration {
 	if m == nil {
 		return (*AggregatedDuration)(nil)
 	}
-	r := AggregatedDurationFromVTPool()
+	r := new(AggregatedDuration)
 	r.Count = m.Count
 	r.Sum = m.Sum
 	if len(m.unknownFields) > 0 {
@@ -442,121 +441,6 @@ func (m *AggregatedDuration) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Metricset = sync.Pool{
-	New: func() interface{} {
-		return &Metricset{}
-	},
-}
-
-func (m *Metricset) ResetVT() {
-	if m != nil {
-		for _, mm := range m.Samples {
-			mm.ResetVT()
-		}
-		f0 := m.Samples[:0]
-		m.Reset()
-		m.Samples = f0
-	}
-}
-func (m *Metricset) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Metricset.Put(m)
-	}
-}
-func MetricsetFromVTPool() *Metricset {
-	return vtprotoPool_Metricset.Get().(*Metricset)
-}
-
-var vtprotoPool_MetricsetSample = sync.Pool{
-	New: func() interface{} {
-		return &MetricsetSample{}
-	},
-}
-
-func (m *MetricsetSample) ResetVT() {
-	if m != nil {
-		m.Histogram.ReturnToVTPool()
-		m.Summary.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *MetricsetSample) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_MetricsetSample.Put(m)
-	}
-}
-func MetricsetSampleFromVTPool() *MetricsetSample {
-	return vtprotoPool_MetricsetSample.Get().(*MetricsetSample)
-}
-
-var vtprotoPool_Histogram = sync.Pool{
-	New: func() interface{} {
-		return &Histogram{}
-	},
-}
-
-func (m *Histogram) ResetVT() {
-	if m != nil {
-		f0 := m.Values[:0]
-		f1 := m.Counts[:0]
-		m.Reset()
-		m.Values = f0
-		m.Counts = f1
-	}
-}
-func (m *Histogram) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Histogram.Put(m)
-	}
-}
-func HistogramFromVTPool() *Histogram {
-	return vtprotoPool_Histogram.Get().(*Histogram)
-}
-
-var vtprotoPool_SummaryMetric = sync.Pool{
-	New: func() interface{} {
-		return &SummaryMetric{}
-	},
-}
-
-func (m *SummaryMetric) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *SummaryMetric) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_SummaryMetric.Put(m)
-	}
-}
-func SummaryMetricFromVTPool() *SummaryMetric {
-	return vtprotoPool_SummaryMetric.Get().(*SummaryMetric)
-}
-
-var vtprotoPool_AggregatedDuration = sync.Pool{
-	New: func() interface{} {
-		return &AggregatedDuration{}
-	},
-}
-
-func (m *AggregatedDuration) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *AggregatedDuration) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_AggregatedDuration.Put(m)
-	}
-}
-func AggregatedDurationFromVTPool() *AggregatedDuration {
-	return vtprotoPool_AggregatedDuration.Get().(*AggregatedDuration)
-}
 func (m *Metricset) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -790,14 +674,7 @@ func (m *Metricset) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Samples) == cap(m.Samples) {
-				m.Samples = append(m.Samples, &MetricsetSample{})
-			} else {
-				m.Samples = m.Samples[:len(m.Samples)+1]
-				if m.Samples[len(m.Samples)-1] == nil {
-					m.Samples[len(m.Samples)-1] = &MetricsetSample{}
-				}
-			}
+			m.Samples = append(m.Samples, &MetricsetSample{})
 			if err := m.Samples[len(m.Samples)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -985,7 +862,7 @@ func (m *MetricsetSample) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Histogram == nil {
-				m.Histogram = HistogramFromVTPool()
+				m.Histogram = &Histogram{}
 			}
 			if err := m.Histogram.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1021,7 +898,7 @@ func (m *MetricsetSample) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Summary == nil {
-				m.Summary = SummaryMetricFromVTPool()
+				m.Summary = &SummaryMetric{}
 			}
 			if err := m.Summary.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1127,7 +1004,7 @@ func (m *Histogram) UnmarshalVT(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Values) == 0 && cap(m.Values) < elementCount {
+				if elementCount != 0 && len(m.Values) == 0 {
 					m.Values = make([]float64, 0, elementCount)
 				}
 				for iNdEx < postIndex {
@@ -1195,7 +1072,7 @@ func (m *Histogram) UnmarshalVT(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Counts) == 0 && cap(m.Counts) < elementCount {
+				if elementCount != 0 && len(m.Counts) == 0 {
 					m.Counts = make([]uint64, 0, elementCount)
 				}
 				for iNdEx < postIndex {

--- a/model/modelpb/network_vtproto.pb.go
+++ b/model/modelpb/network_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Network) CloneVT() *Network {
 	if m == nil {
 		return (*Network)(nil)
 	}
-	r := NetworkFromVTPool()
+	r := new(Network)
 	r.Connection = m.Connection.CloneVT()
 	r.Carrier = m.Carrier.CloneVT()
 	if len(m.unknownFields) > 0 {
@@ -60,7 +59,7 @@ func (m *NetworkConnection) CloneVT() *NetworkConnection {
 	if m == nil {
 		return (*NetworkConnection)(nil)
 	}
-	r := NetworkConnectionFromVTPool()
+	r := new(NetworkConnection)
 	r.Type = m.Type
 	r.Subtype = m.Subtype
 	if len(m.unknownFields) > 0 {
@@ -78,7 +77,7 @@ func (m *NetworkCarrier) CloneVT() *NetworkCarrier {
 	if m == nil {
 		return (*NetworkCarrier)(nil)
 	}
-	r := NetworkCarrierFromVTPool()
+	r := new(NetworkCarrier)
 	r.Name = m.Name
 	r.Mcc = m.Mcc
 	r.Mnc = m.Mnc
@@ -255,70 +254,6 @@ func (m *NetworkCarrier) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Network = sync.Pool{
-	New: func() interface{} {
-		return &Network{}
-	},
-}
-
-func (m *Network) ResetVT() {
-	if m != nil {
-		m.Connection.ReturnToVTPool()
-		m.Carrier.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *Network) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Network.Put(m)
-	}
-}
-func NetworkFromVTPool() *Network {
-	return vtprotoPool_Network.Get().(*Network)
-}
-
-var vtprotoPool_NetworkConnection = sync.Pool{
-	New: func() interface{} {
-		return &NetworkConnection{}
-	},
-}
-
-func (m *NetworkConnection) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *NetworkConnection) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_NetworkConnection.Put(m)
-	}
-}
-func NetworkConnectionFromVTPool() *NetworkConnection {
-	return vtprotoPool_NetworkConnection.Get().(*NetworkConnection)
-}
-
-var vtprotoPool_NetworkCarrier = sync.Pool{
-	New: func() interface{} {
-		return &NetworkCarrier{}
-	},
-}
-
-func (m *NetworkCarrier) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *NetworkCarrier) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_NetworkCarrier.Put(m)
-	}
-}
-func NetworkCarrierFromVTPool() *NetworkCarrier {
-	return vtprotoPool_NetworkCarrier.Get().(*NetworkCarrier)
-}
 func (m *Network) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -440,7 +375,7 @@ func (m *Network) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Connection == nil {
-				m.Connection = NetworkConnectionFromVTPool()
+				m.Connection = &NetworkConnection{}
 			}
 			if err := m.Connection.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -476,7 +411,7 @@ func (m *Network) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Carrier == nil {
-				m.Carrier = NetworkCarrierFromVTPool()
+				m.Carrier = &NetworkCarrier{}
 			}
 			if err := m.Carrier.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/observer_vtproto.pb.go
+++ b/model/modelpb/observer_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Observer) CloneVT() *Observer {
 	if m == nil {
 		return (*Observer)(nil)
 	}
-	r := ObserverFromVTPool()
+	r := new(Observer)
 	r.Hostname = m.Hostname
 	r.Name = m.Name
 	r.Type = m.Type
@@ -119,26 +118,6 @@ func (m *Observer) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Observer = sync.Pool{
-	New: func() interface{} {
-		return &Observer{}
-	},
-}
-
-func (m *Observer) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Observer) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Observer.Put(m)
-	}
-}
-func ObserverFromVTPool() *Observer {
-	return vtprotoPool_Observer.Get().(*Observer)
-}
 func (m *Observer) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/os_vtproto.pb.go
+++ b/model/modelpb/os_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *OS) CloneVT() *OS {
 	if m == nil {
 		return (*OS)(nil)
 	}
-	r := OSFromVTPool()
+	r := new(OS)
 	r.Name = m.Name
 	r.Version = m.Version
 	r.Platform = m.Platform
@@ -127,26 +126,6 @@ func (m *OS) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_OS = sync.Pool{
-	New: func() interface{} {
-		return &OS{}
-	},
-}
-
-func (m *OS) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *OS) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_OS.Put(m)
-	}
-}
-func OSFromVTPool() *OS {
-	return vtprotoPool_OS.Get().(*OS)
-}
 func (m *OS) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/process_vtproto.pb.go
+++ b/model/modelpb/process_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Process) CloneVT() *Process {
 	if m == nil {
 		return (*Process)(nil)
 	}
-	r := ProcessFromVTPool()
+	r := new(Process)
 	r.Ppid = m.Ppid
 	r.Thread = m.Thread.CloneVT()
 	r.Title = m.Title
@@ -69,7 +68,7 @@ func (m *ProcessThread) CloneVT() *ProcessThread {
 	if m == nil {
 		return (*ProcessThread)(nil)
 	}
-	r := ProcessThreadFromVTPool()
+	r := new(ProcessThread)
 	r.Name = m.Name
 	r.Id = m.Id
 	if len(m.unknownFields) > 0 {
@@ -211,50 +210,6 @@ func (m *ProcessThread) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Process = sync.Pool{
-	New: func() interface{} {
-		return &Process{}
-	},
-}
-
-func (m *Process) ResetVT() {
-	if m != nil {
-		m.Thread.ReturnToVTPool()
-		f0 := m.Argv[:0]
-		m.Reset()
-		m.Argv = f0
-	}
-}
-func (m *Process) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Process.Put(m)
-	}
-}
-func ProcessFromVTPool() *Process {
-	return vtprotoPool_Process.Get().(*Process)
-}
-
-var vtprotoPool_ProcessThread = sync.Pool{
-	New: func() interface{} {
-		return &ProcessThread{}
-	},
-}
-
-func (m *ProcessThread) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *ProcessThread) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_ProcessThread.Put(m)
-	}
-}
-func ProcessThreadFromVTPool() *ProcessThread {
-	return vtprotoPool_ProcessThread.Get().(*ProcessThread)
-}
 func (m *Process) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -388,7 +343,7 @@ func (m *Process) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Thread == nil {
-				m.Thread = ProcessThreadFromVTPool()
+				m.Thread = &ProcessThread{}
 			}
 			if err := m.Thread.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/service_vtproto.pb.go
+++ b/model/modelpb/service_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Service) CloneVT() *Service {
 	if m == nil {
 		return (*Service)(nil)
 	}
-	r := ServiceFromVTPool()
+	r := new(Service)
 	r.Origin = m.Origin.CloneVT()
 	r.Target = m.Target.CloneVT()
 	r.Language = m.Language.CloneVT()
@@ -67,7 +66,7 @@ func (m *ServiceOrigin) CloneVT() *ServiceOrigin {
 	if m == nil {
 		return (*ServiceOrigin)(nil)
 	}
-	r := ServiceOriginFromVTPool()
+	r := new(ServiceOrigin)
 	r.Id = m.Id
 	r.Name = m.Name
 	r.Version = m.Version
@@ -86,7 +85,7 @@ func (m *ServiceTarget) CloneVT() *ServiceTarget {
 	if m == nil {
 		return (*ServiceTarget)(nil)
 	}
-	r := ServiceTargetFromVTPool()
+	r := new(ServiceTarget)
 	r.Name = m.Name
 	r.Type = m.Type
 	if len(m.unknownFields) > 0 {
@@ -104,7 +103,7 @@ func (m *Language) CloneVT() *Language {
 	if m == nil {
 		return (*Language)(nil)
 	}
-	r := LanguageFromVTPool()
+	r := new(Language)
 	r.Name = m.Name
 	r.Version = m.Version
 	if len(m.unknownFields) > 0 {
@@ -122,7 +121,7 @@ func (m *Runtime) CloneVT() *Runtime {
 	if m == nil {
 		return (*Runtime)(nil)
 	}
-	r := RuntimeFromVTPool()
+	r := new(Runtime)
 	r.Name = m.Name
 	r.Version = m.Version
 	if len(m.unknownFields) > 0 {
@@ -140,7 +139,7 @@ func (m *Framework) CloneVT() *Framework {
 	if m == nil {
 		return (*Framework)(nil)
 	}
-	r := FrameworkFromVTPool()
+	r := new(Framework)
 	r.Name = m.Name
 	r.Version = m.Version
 	if len(m.unknownFields) > 0 {
@@ -158,7 +157,7 @@ func (m *ServiceNode) CloneVT() *ServiceNode {
 	if m == nil {
 		return (*ServiceNode)(nil)
 	}
-	r := ServiceNodeFromVTPool()
+	r := new(ServiceNode)
 	r.Name = m.Name
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -567,158 +566,6 @@ func (m *ServiceNode) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Service = sync.Pool{
-	New: func() interface{} {
-		return &Service{}
-	},
-}
-
-func (m *Service) ResetVT() {
-	if m != nil {
-		m.Origin.ReturnToVTPool()
-		m.Target.ReturnToVTPool()
-		m.Language.ReturnToVTPool()
-		m.Runtime.ReturnToVTPool()
-		m.Framework.ReturnToVTPool()
-		m.Node.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *Service) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Service.Put(m)
-	}
-}
-func ServiceFromVTPool() *Service {
-	return vtprotoPool_Service.Get().(*Service)
-}
-
-var vtprotoPool_ServiceOrigin = sync.Pool{
-	New: func() interface{} {
-		return &ServiceOrigin{}
-	},
-}
-
-func (m *ServiceOrigin) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *ServiceOrigin) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_ServiceOrigin.Put(m)
-	}
-}
-func ServiceOriginFromVTPool() *ServiceOrigin {
-	return vtprotoPool_ServiceOrigin.Get().(*ServiceOrigin)
-}
-
-var vtprotoPool_ServiceTarget = sync.Pool{
-	New: func() interface{} {
-		return &ServiceTarget{}
-	},
-}
-
-func (m *ServiceTarget) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *ServiceTarget) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_ServiceTarget.Put(m)
-	}
-}
-func ServiceTargetFromVTPool() *ServiceTarget {
-	return vtprotoPool_ServiceTarget.Get().(*ServiceTarget)
-}
-
-var vtprotoPool_Language = sync.Pool{
-	New: func() interface{} {
-		return &Language{}
-	},
-}
-
-func (m *Language) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Language) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Language.Put(m)
-	}
-}
-func LanguageFromVTPool() *Language {
-	return vtprotoPool_Language.Get().(*Language)
-}
-
-var vtprotoPool_Runtime = sync.Pool{
-	New: func() interface{} {
-		return &Runtime{}
-	},
-}
-
-func (m *Runtime) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Runtime) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Runtime.Put(m)
-	}
-}
-func RuntimeFromVTPool() *Runtime {
-	return vtprotoPool_Runtime.Get().(*Runtime)
-}
-
-var vtprotoPool_Framework = sync.Pool{
-	New: func() interface{} {
-		return &Framework{}
-	},
-}
-
-func (m *Framework) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Framework) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Framework.Put(m)
-	}
-}
-func FrameworkFromVTPool() *Framework {
-	return vtprotoPool_Framework.Get().(*Framework)
-}
-
-var vtprotoPool_ServiceNode = sync.Pool{
-	New: func() interface{} {
-		return &ServiceNode{}
-	},
-}
-
-func (m *ServiceNode) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *ServiceNode) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_ServiceNode.Put(m)
-	}
-}
-func ServiceNodeFromVTPool() *ServiceNode {
-	return vtprotoPool_ServiceNode.Get().(*ServiceNode)
-}
 func (m *Service) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -932,7 +779,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Origin == nil {
-				m.Origin = ServiceOriginFromVTPool()
+				m.Origin = &ServiceOrigin{}
 			}
 			if err := m.Origin.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -968,7 +815,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Target == nil {
-				m.Target = ServiceTargetFromVTPool()
+				m.Target = &ServiceTarget{}
 			}
 			if err := m.Target.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1004,7 +851,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Language == nil {
-				m.Language = LanguageFromVTPool()
+				m.Language = &Language{}
 			}
 			if err := m.Language.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1040,7 +887,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Runtime == nil {
-				m.Runtime = RuntimeFromVTPool()
+				m.Runtime = &Runtime{}
 			}
 			if err := m.Runtime.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1076,7 +923,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Framework == nil {
-				m.Framework = FrameworkFromVTPool()
+				m.Framework = &Framework{}
 			}
 			if err := m.Framework.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1208,7 +1055,7 @@ func (m *Service) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Node == nil {
-				m.Node = ServiceNodeFromVTPool()
+				m.Node = &ServiceNode{}
 			}
 			if err := m.Node.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/session_vtproto.pb.go
+++ b/model/modelpb/session_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Session) CloneVT() *Session {
 	if m == nil {
 		return (*Session)(nil)
 	}
-	r := SessionFromVTPool()
+	r := new(Session)
 	r.Id = m.Id
 	r.Sequence = m.Sequence
 	if len(m.unknownFields) > 0 {
@@ -101,26 +100,6 @@ func (m *Session) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Session = sync.Pool{
-	New: func() interface{} {
-		return &Session{}
-	},
-}
-
-func (m *Session) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Session) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Session.Put(m)
-	}
-}
-func SessionFromVTPool() *Session {
-	return vtprotoPool_Session.Get().(*Session)
-}
 func (m *Session) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/source_vtproto.pb.go
+++ b/model/modelpb/source_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Source) CloneVT() *Source {
 	if m == nil {
 		return (*Source)(nil)
 	}
-	r := SourceFromVTPool()
+	r := new(Source)
 	r.Ip = m.Ip.CloneVT()
 	r.Nat = m.Nat.CloneVT()
 	r.Domain = m.Domain
@@ -62,7 +61,7 @@ func (m *NAT) CloneVT() *NAT {
 	if m == nil {
 		return (*NAT)(nil)
 	}
-	r := NATFromVTPool()
+	r := new(NAT)
 	r.Ip = m.Ip.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -183,50 +182,6 @@ func (m *NAT) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Source = sync.Pool{
-	New: func() interface{} {
-		return &Source{}
-	},
-}
-
-func (m *Source) ResetVT() {
-	if m != nil {
-		m.Ip.ReturnToVTPool()
-		m.Nat.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *Source) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Source.Put(m)
-	}
-}
-func SourceFromVTPool() *Source {
-	return vtprotoPool_Source.Get().(*Source)
-}
-
-var vtprotoPool_NAT = sync.Pool{
-	New: func() interface{} {
-		return &NAT{}
-	},
-}
-
-func (m *NAT) ResetVT() {
-	if m != nil {
-		m.Ip.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *NAT) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_NAT.Put(m)
-	}
-}
-func NATFromVTPool() *NAT {
-	return vtprotoPool_NAT.Get().(*NAT)
-}
 func (m *Source) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -325,7 +280,7 @@ func (m *Source) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Ip == nil {
-				m.Ip = IPFromVTPool()
+				m.Ip = &IP{}
 			}
 			if err := m.Ip.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -361,7 +316,7 @@ func (m *Source) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Nat == nil {
-				m.Nat = NATFromVTPool()
+				m.Nat = &NAT{}
 			}
 			if err := m.Nat.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -499,7 +454,7 @@ func (m *NAT) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Ip == nil {
-				m.Ip = IPFromVTPool()
+				m.Ip = &IP{}
 			}
 			if err := m.Ip.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/span_vtproto.pb.go
+++ b/model/modelpb/span_vtproto.pb.go
@@ -26,7 +26,6 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -44,7 +43,7 @@ func (m *Span) CloneVT() *Span {
 	if m == nil {
 		return (*Span)(nil)
 	}
-	r := SpanFromVTPool()
+	r := new(Span)
 	r.Message = m.Message.CloneVT()
 	r.Composite = m.Composite.CloneVT()
 	r.DestinationService = m.DestinationService.CloneVT()
@@ -90,7 +89,7 @@ func (m *DB) CloneVT() *DB {
 	if m == nil {
 		return (*DB)(nil)
 	}
-	r := DBFromVTPool()
+	r := new(DB)
 	r.Instance = m.Instance
 	r.Statement = m.Statement
 	r.Type = m.Type
@@ -115,7 +114,7 @@ func (m *DestinationService) CloneVT() *DestinationService {
 	if m == nil {
 		return (*DestinationService)(nil)
 	}
-	r := DestinationServiceFromVTPool()
+	r := new(DestinationService)
 	r.Type = m.Type
 	r.Name = m.Name
 	r.Resource = m.Resource
@@ -135,7 +134,7 @@ func (m *Composite) CloneVT() *Composite {
 	if m == nil {
 		return (*Composite)(nil)
 	}
-	r := CompositeFromVTPool()
+	r := new(Composite)
 	r.CompressionStrategy = m.CompressionStrategy
 	r.Count = m.Count
 	r.Sum = m.Sum
@@ -154,7 +153,7 @@ func (m *SpanLink) CloneVT() *SpanLink {
 	if m == nil {
 		return (*SpanLink)(nil)
 	}
-	r := SpanLinkFromVTPool()
+	r := new(SpanLink)
 	r.TraceId = m.TraceId
 	r.SpanId = m.SpanId
 	if len(m.unknownFields) > 0 {
@@ -566,126 +565,6 @@ func (m *SpanLink) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Span = sync.Pool{
-	New: func() interface{} {
-		return &Span{}
-	},
-}
-
-func (m *Span) ResetVT() {
-	if m != nil {
-		m.Message.ReturnToVTPool()
-		m.Composite.ReturnToVTPool()
-		m.DestinationService.ReturnToVTPool()
-		m.Db.ReturnToVTPool()
-		for _, mm := range m.Stacktrace {
-			mm.ResetVT()
-		}
-		f0 := m.Stacktrace[:0]
-		for _, mm := range m.Links {
-			mm.ResetVT()
-		}
-		f1 := m.Links[:0]
-		m.SelfTime.ReturnToVTPool()
-		m.Reset()
-		m.Stacktrace = f0
-		m.Links = f1
-	}
-}
-func (m *Span) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Span.Put(m)
-	}
-}
-func SpanFromVTPool() *Span {
-	return vtprotoPool_Span.Get().(*Span)
-}
-
-var vtprotoPool_DB = sync.Pool{
-	New: func() interface{} {
-		return &DB{}
-	},
-}
-
-func (m *DB) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *DB) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_DB.Put(m)
-	}
-}
-func DBFromVTPool() *DB {
-	return vtprotoPool_DB.Get().(*DB)
-}
-
-var vtprotoPool_DestinationService = sync.Pool{
-	New: func() interface{} {
-		return &DestinationService{}
-	},
-}
-
-func (m *DestinationService) ResetVT() {
-	if m != nil {
-		m.ResponseTime.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *DestinationService) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_DestinationService.Put(m)
-	}
-}
-func DestinationServiceFromVTPool() *DestinationService {
-	return vtprotoPool_DestinationService.Get().(*DestinationService)
-}
-
-var vtprotoPool_Composite = sync.Pool{
-	New: func() interface{} {
-		return &Composite{}
-	},
-}
-
-func (m *Composite) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Composite) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Composite.Put(m)
-	}
-}
-func CompositeFromVTPool() *Composite {
-	return vtprotoPool_Composite.Get().(*Composite)
-}
-
-var vtprotoPool_SpanLink = sync.Pool{
-	New: func() interface{} {
-		return &SpanLink{}
-	},
-}
-
-func (m *SpanLink) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *SpanLink) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_SpanLink.Put(m)
-	}
-}
-func SpanLinkFromVTPool() *SpanLink {
-	return vtprotoPool_SpanLink.Get().(*SpanLink)
-}
 func (m *Span) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -913,7 +792,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Message == nil {
-				m.Message = MessageFromVTPool()
+				m.Message = &Message{}
 			}
 			if err := m.Message.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -949,7 +828,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Composite == nil {
-				m.Composite = CompositeFromVTPool()
+				m.Composite = &Composite{}
 			}
 			if err := m.Composite.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -985,7 +864,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.DestinationService == nil {
-				m.DestinationService = DestinationServiceFromVTPool()
+				m.DestinationService = &DestinationService{}
 			}
 			if err := m.DestinationService.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1021,7 +900,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Db == nil {
-				m.Db = DBFromVTPool()
+				m.Db = &DB{}
 			}
 			if err := m.Db.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1269,14 +1148,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Stacktrace) == cap(m.Stacktrace) {
-				m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
-			} else {
-				m.Stacktrace = m.Stacktrace[:len(m.Stacktrace)+1]
-				if m.Stacktrace[len(m.Stacktrace)-1] == nil {
-					m.Stacktrace[len(m.Stacktrace)-1] = &StacktraceFrame{}
-				}
-			}
+			m.Stacktrace = append(m.Stacktrace, &StacktraceFrame{})
 			if err := m.Stacktrace[len(m.Stacktrace)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1310,14 +1182,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Links) == cap(m.Links) {
-				m.Links = append(m.Links, &SpanLink{})
-			} else {
-				m.Links = m.Links[:len(m.Links)+1]
-				if m.Links[len(m.Links)-1] == nil {
-					m.Links[len(m.Links)-1] = &SpanLink{}
-				}
-			}
+			m.Links = append(m.Links, &SpanLink{})
 			if err := m.Links[len(m.Links)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1352,7 +1217,7 @@ func (m *Span) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.SelfTime == nil {
-				m.SelfTime = AggregatedDurationFromVTPool()
+				m.SelfTime = &AggregatedDuration{}
 			}
 			if err := m.SelfTime.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1777,7 +1642,7 @@ func (m *DestinationService) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.ResponseTime == nil {
-				m.ResponseTime = AggregatedDurationFromVTPool()
+				m.ResponseTime = &AggregatedDuration{}
 			}
 			if err := m.ResponseTime.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/stacktrace_vtproto.pb.go
+++ b/model/modelpb/stacktrace_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *StacktraceFrame) CloneVT() *StacktraceFrame {
 	if m == nil {
 		return (*StacktraceFrame)(nil)
 	}
-	r := StacktraceFrameFromVTPool()
+	r := new(StacktraceFrame)
 	r.Filename = m.Filename
 	r.Classname = m.Classname
 	r.ContextLine = m.ContextLine
@@ -94,7 +93,7 @@ func (m *Original) CloneVT() *Original {
 	if m == nil {
 		return (*Original)(nil)
 	}
-	r := OriginalFromVTPool()
+	r := new(Original)
 	r.AbsPath = m.AbsPath
 	r.Filename = m.Filename
 	r.Classname = m.Classname
@@ -364,57 +363,6 @@ func (m *Original) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_StacktraceFrame = sync.Pool{
-	New: func() interface{} {
-		return &StacktraceFrame{}
-	},
-}
-
-func (m *StacktraceFrame) ResetVT() {
-	if m != nil {
-		for _, mm := range m.Vars {
-			mm.ResetVT()
-		}
-		f0 := m.Vars[:0]
-		m.Original.ReturnToVTPool()
-		f1 := m.PreContext[:0]
-		f2 := m.PostContext[:0]
-		m.Reset()
-		m.Vars = f0
-		m.PreContext = f1
-		m.PostContext = f2
-	}
-}
-func (m *StacktraceFrame) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_StacktraceFrame.Put(m)
-	}
-}
-func StacktraceFrameFromVTPool() *StacktraceFrame {
-	return vtprotoPool_StacktraceFrame.Get().(*StacktraceFrame)
-}
-
-var vtprotoPool_Original = sync.Pool{
-	New: func() interface{} {
-		return &Original{}
-	},
-}
-
-func (m *Original) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Original) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Original.Put(m)
-	}
-}
-func OriginalFromVTPool() *Original {
-	return vtprotoPool_Original.Get().(*Original)
-}
 func (m *StacktraceFrame) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -583,14 +531,7 @@ func (m *StacktraceFrame) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Vars) == cap(m.Vars) {
-				m.Vars = append(m.Vars, &KeyValue{})
-			} else {
-				m.Vars = m.Vars[:len(m.Vars)+1]
-				if m.Vars[len(m.Vars)-1] == nil {
-					m.Vars[len(m.Vars)-1] = &KeyValue{}
-				}
-			}
+			m.Vars = append(m.Vars, &KeyValue{})
 			if err := m.Vars[len(m.Vars)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -889,7 +830,7 @@ func (m *StacktraceFrame) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Original == nil {
-				m.Original = OriginalFromVTPool()
+				m.Original = &Original{}
 			}
 			if err := m.Original.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/system_vtproto.pb.go
+++ b/model/modelpb/system_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *System) CloneVT() *System {
 	if m == nil {
 		return (*System)(nil)
 	}
-	r := SystemFromVTPool()
+	r := new(System)
 	r.Process = m.Process.CloneVT()
 	r.Filesystem = m.Filesystem.CloneVT()
 	if len(m.unknownFields) > 0 {
@@ -60,7 +59,7 @@ func (m *SystemProcess) CloneVT() *SystemProcess {
 	if m == nil {
 		return (*SystemProcess)(nil)
 	}
-	r := SystemProcessFromVTPool()
+	r := new(SystemProcess)
 	r.Cpu = m.Cpu.CloneVT()
 	r.State = m.State
 	r.Cmdline = m.Cmdline
@@ -79,7 +78,7 @@ func (m *SystemProcessCPU) CloneVT() *SystemProcessCPU {
 	if m == nil {
 		return (*SystemProcessCPU)(nil)
 	}
-	r := SystemProcessCPUFromVTPool()
+	r := new(SystemProcessCPU)
 	r.StartTime = m.StartTime
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -96,7 +95,7 @@ func (m *SystemFilesystem) CloneVT() *SystemFilesystem {
 	if m == nil {
 		return (*SystemFilesystem)(nil)
 	}
-	r := SystemFilesystemFromVTPool()
+	r := new(SystemFilesystem)
 	r.MountPoint = m.MountPoint
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -299,92 +298,6 @@ func (m *SystemFilesystem) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_System = sync.Pool{
-	New: func() interface{} {
-		return &System{}
-	},
-}
-
-func (m *System) ResetVT() {
-	if m != nil {
-		m.Process.ReturnToVTPool()
-		m.Filesystem.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *System) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_System.Put(m)
-	}
-}
-func SystemFromVTPool() *System {
-	return vtprotoPool_System.Get().(*System)
-}
-
-var vtprotoPool_SystemProcess = sync.Pool{
-	New: func() interface{} {
-		return &SystemProcess{}
-	},
-}
-
-func (m *SystemProcess) ResetVT() {
-	if m != nil {
-		m.Cpu.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *SystemProcess) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_SystemProcess.Put(m)
-	}
-}
-func SystemProcessFromVTPool() *SystemProcess {
-	return vtprotoPool_SystemProcess.Get().(*SystemProcess)
-}
-
-var vtprotoPool_SystemProcessCPU = sync.Pool{
-	New: func() interface{} {
-		return &SystemProcessCPU{}
-	},
-}
-
-func (m *SystemProcessCPU) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *SystemProcessCPU) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_SystemProcessCPU.Put(m)
-	}
-}
-func SystemProcessCPUFromVTPool() *SystemProcessCPU {
-	return vtprotoPool_SystemProcessCPU.Get().(*SystemProcessCPU)
-}
-
-var vtprotoPool_SystemFilesystem = sync.Pool{
-	New: func() interface{} {
-		return &SystemFilesystem{}
-	},
-}
-
-func (m *SystemFilesystem) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *SystemFilesystem) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_SystemFilesystem.Put(m)
-	}
-}
-func SystemFilesystemFromVTPool() *SystemFilesystem {
-	return vtprotoPool_SystemFilesystem.Get().(*SystemFilesystem)
-}
 func (m *System) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -512,7 +425,7 @@ func (m *System) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Process == nil {
-				m.Process = SystemProcessFromVTPool()
+				m.Process = &SystemProcess{}
 			}
 			if err := m.Process.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -548,7 +461,7 @@ func (m *System) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Filesystem == nil {
-				m.Filesystem = SystemFilesystemFromVTPool()
+				m.Filesystem = &SystemFilesystem{}
 			}
 			if err := m.Filesystem.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -635,7 +548,7 @@ func (m *SystemProcess) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Cpu == nil {
-				m.Cpu = SystemProcessCPUFromVTPool()
+				m.Cpu = &SystemProcessCPU{}
 			}
 			if err := m.Cpu.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/trace_vtproto.pb.go
+++ b/model/modelpb/trace_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *Trace) CloneVT() *Trace {
 	if m == nil {
 		return (*Trace)(nil)
 	}
-	r := TraceFromVTPool()
+	r := new(Trace)
 	r.Id = m.Id
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -95,26 +94,6 @@ func (m *Trace) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Trace = sync.Pool{
-	New: func() interface{} {
-		return &Trace{}
-	},
-}
-
-func (m *Trace) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *Trace) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Trace.Put(m)
-	}
-}
-func TraceFromVTPool() *Trace {
-	return vtprotoPool_Trace.Get().(*Trace)
-}
 func (m *Trace) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/transaction_vtproto.pb.go
+++ b/model/modelpb/transaction_vtproto.pb.go
@@ -26,7 +26,6 @@ import (
 	fmt "fmt"
 	io "io"
 	math "math"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -44,7 +43,7 @@ func (m *Transaction) CloneVT() *Transaction {
 	if m == nil {
 		return (*Transaction)(nil)
 	}
-	r := TransactionFromVTPool()
+	r := new(Transaction)
 	r.SpanCount = m.SpanCount.CloneVT()
 	r.UserExperience = m.UserExperience.CloneVT()
 	r.Message = m.Message.CloneVT()
@@ -98,7 +97,7 @@ func (m *SpanCount) CloneVT() *SpanCount {
 	if m == nil {
 		return (*SpanCount)(nil)
 	}
-	r := SpanCountFromVTPool()
+	r := new(SpanCount)
 	if rhs := m.Dropped; rhs != nil {
 		tmpVal := *rhs
 		r.Dropped = &tmpVal
@@ -122,7 +121,7 @@ func (m *TransactionMark) CloneVT() *TransactionMark {
 	if m == nil {
 		return (*TransactionMark)(nil)
 	}
-	r := TransactionMarkFromVTPool()
+	r := new(TransactionMark)
 	if rhs := m.Measurements; rhs != nil {
 		tmpContainer := make(map[string]float64, len(rhs))
 		for k, v := range rhs {
@@ -145,7 +144,7 @@ func (m *DroppedSpanStats) CloneVT() *DroppedSpanStats {
 	if m == nil {
 		return (*DroppedSpanStats)(nil)
 	}
-	r := DroppedSpanStatsFromVTPool()
+	r := new(DroppedSpanStats)
 	r.DestinationServiceResource = m.DestinationServiceResource
 	r.ServiceTargetType = m.ServiceTargetType
 	r.ServiceTargetName = m.ServiceTargetName
@@ -521,107 +520,6 @@ func (m *DroppedSpanStats) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_Transaction = sync.Pool{
-	New: func() interface{} {
-		return &Transaction{}
-	},
-}
-
-func (m *Transaction) ResetVT() {
-	if m != nil {
-		m.SpanCount.ReturnToVTPool()
-		m.UserExperience.ReturnToVTPool()
-		for _, mm := range m.Custom {
-			mm.ResetVT()
-		}
-		f0 := m.Custom[:0]
-		m.Message.ReturnToVTPool()
-		m.DurationHistogram.ReturnToVTPool()
-		for _, mm := range m.DroppedSpansStats {
-			mm.ResetVT()
-		}
-		f1 := m.DroppedSpansStats[:0]
-		m.DurationSummary.ReturnToVTPool()
-		f2 := m.ProfilerStackTraceIds[:0]
-		m.Reset()
-		m.Custom = f0
-		m.DroppedSpansStats = f1
-		m.ProfilerStackTraceIds = f2
-	}
-}
-func (m *Transaction) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Transaction.Put(m)
-	}
-}
-func TransactionFromVTPool() *Transaction {
-	return vtprotoPool_Transaction.Get().(*Transaction)
-}
-
-var vtprotoPool_SpanCount = sync.Pool{
-	New: func() interface{} {
-		return &SpanCount{}
-	},
-}
-
-func (m *SpanCount) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *SpanCount) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_SpanCount.Put(m)
-	}
-}
-func SpanCountFromVTPool() *SpanCount {
-	return vtprotoPool_SpanCount.Get().(*SpanCount)
-}
-
-var vtprotoPool_TransactionMark = sync.Pool{
-	New: func() interface{} {
-		return &TransactionMark{}
-	},
-}
-
-func (m *TransactionMark) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *TransactionMark) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_TransactionMark.Put(m)
-	}
-}
-func TransactionMarkFromVTPool() *TransactionMark {
-	return vtprotoPool_TransactionMark.Get().(*TransactionMark)
-}
-
-var vtprotoPool_DroppedSpanStats = sync.Pool{
-	New: func() interface{} {
-		return &DroppedSpanStats{}
-	},
-}
-
-func (m *DroppedSpanStats) ResetVT() {
-	if m != nil {
-		m.Duration.ReturnToVTPool()
-		m.Reset()
-	}
-}
-func (m *DroppedSpanStats) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_DroppedSpanStats.Put(m)
-	}
-}
-func DroppedSpanStatsFromVTPool() *DroppedSpanStats {
-	return vtprotoPool_DroppedSpanStats.Get().(*DroppedSpanStats)
-}
 func (m *Transaction) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -831,7 +729,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.SpanCount == nil {
-				m.SpanCount = SpanCountFromVTPool()
+				m.SpanCount = &SpanCount{}
 			}
 			if err := m.SpanCount.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -867,7 +765,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.UserExperience == nil {
-				m.UserExperience = UserExperienceFromVTPool()
+				m.UserExperience = &UserExperience{}
 			}
 			if err := m.UserExperience.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -902,14 +800,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Custom) == cap(m.Custom) {
-				m.Custom = append(m.Custom, &KeyValue{})
-			} else {
-				m.Custom = m.Custom[:len(m.Custom)+1]
-				if m.Custom[len(m.Custom)-1] == nil {
-					m.Custom[len(m.Custom)-1] = &KeyValue{}
-				}
-			}
+			m.Custom = append(m.Custom, &KeyValue{})
 			if err := m.Custom[len(m.Custom)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1073,7 +964,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Message == nil {
-				m.Message = MessageFromVTPool()
+				m.Message = &Message{}
 			}
 			if err := m.Message.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1237,7 +1128,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.DurationHistogram == nil {
-				m.DurationHistogram = HistogramFromVTPool()
+				m.DurationHistogram = &Histogram{}
 			}
 			if err := m.DurationHistogram.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1272,14 +1163,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.DroppedSpansStats) == cap(m.DroppedSpansStats) {
-				m.DroppedSpansStats = append(m.DroppedSpansStats, &DroppedSpanStats{})
-			} else {
-				m.DroppedSpansStats = m.DroppedSpansStats[:len(m.DroppedSpansStats)+1]
-				if m.DroppedSpansStats[len(m.DroppedSpansStats)-1] == nil {
-					m.DroppedSpansStats[len(m.DroppedSpansStats)-1] = &DroppedSpanStats{}
-				}
-			}
+			m.DroppedSpansStats = append(m.DroppedSpansStats, &DroppedSpanStats{})
 			if err := m.DroppedSpansStats[len(m.DroppedSpansStats)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1314,7 +1198,7 @@ func (m *Transaction) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.DurationSummary == nil {
-				m.DurationSummary = SummaryMetricFromVTPool()
+				m.DurationSummary = &SummaryMetric{}
 			}
 			if err := m.DurationSummary.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -1860,7 +1744,7 @@ func (m *DroppedSpanStats) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Duration == nil {
-				m.Duration = AggregatedDurationFromVTPool()
+				m.Duration = &AggregatedDuration{}
 			}
 			if err := m.Duration.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/model/modelpb/url_vtproto.pb.go
+++ b/model/modelpb/url_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *URL) CloneVT() *URL {
 	if m == nil {
 		return (*URL)(nil)
 	}
-	r := URLFromVTPool()
+	r := new(URL)
 	r.Original = m.Original
 	r.Scheme = m.Scheme
 	r.Full = m.Full
@@ -149,26 +148,6 @@ func (m *URL) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_URL = sync.Pool{
-	New: func() interface{} {
-		return &URL{}
-	},
-}
-
-func (m *URL) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *URL) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_URL.Put(m)
-	}
-}
-func URLFromVTPool() *URL {
-	return vtprotoPool_URL.Get().(*URL)
-}
 func (m *URL) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/user_vtproto.pb.go
+++ b/model/modelpb/user_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *User) CloneVT() *User {
 	if m == nil {
 		return (*User)(nil)
 	}
-	r := UserFromVTPool()
+	r := new(User)
 	r.Domain = m.Domain
 	r.Id = m.Id
 	r.Email = m.Email
@@ -119,26 +118,6 @@ func (m *User) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_User = sync.Pool{
-	New: func() interface{} {
-		return &User{}
-	},
-}
-
-func (m *User) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *User) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_User.Put(m)
-	}
-}
-func UserFromVTPool() *User {
-	return vtprotoPool_User.Get().(*User)
-}
 func (m *User) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/model/modelpb/useragent_vtproto.pb.go
+++ b/model/modelpb/useragent_vtproto.pb.go
@@ -24,7 +24,6 @@ package modelpb
 import (
 	fmt "fmt"
 	io "io"
-	sync "sync"
 
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	proto "google.golang.org/protobuf/proto"
@@ -42,7 +41,7 @@ func (m *UserAgent) CloneVT() *UserAgent {
 	if m == nil {
 		return (*UserAgent)(nil)
 	}
-	r := UserAgentFromVTPool()
+	r := new(UserAgent)
 	r.Original = m.Original
 	r.Name = m.Name
 	if len(m.unknownFields) > 0 {
@@ -103,26 +102,6 @@ func (m *UserAgent) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-var vtprotoPool_UserAgent = sync.Pool{
-	New: func() interface{} {
-		return &UserAgent{}
-	},
-}
-
-func (m *UserAgent) ResetVT() {
-	if m != nil {
-		m.Reset()
-	}
-}
-func (m *UserAgent) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_UserAgent.Put(m)
-	}
-}
-func UserAgentFromVTPool() *UserAgent {
-	return vtprotoPool_UserAgent.Get().(*UserAgent)
-}
 func (m *UserAgent) SizeVT() (n int) {
 	if m == nil {
 		return 0

--- a/tools/generate-modelpb.sh
+++ b/tools/generate-modelpb.sh
@@ -3,12 +3,10 @@
 TOOLS_DIR=$(dirname "$(readlink -f -- "$0")")
 
 STRUCTS=$(grep '^message' ./model/proto/*.proto | cut -d ' ' -f2)
-PROTOC_VT_STRUCTS=$(for s in ${STRUCTS}; do echo --go-vtproto_opt=pool=github.com/elastic/apm-data/model/modelpb.$s ;done)
 PATH="${TOOLS_DIR}/build/bin:${PATH}" protoc \
     --proto_path=./model/proto/ \
     --go_out=. \
     --go_opt=module=github.com/elastic/apm-data \
     --go-vtproto_out=. \
-    --go-vtproto_opt=features=marshal+unmarshal+size+pool+clone,module=github.com/elastic/apm-data \
-    ${PROTOC_VT_STRUCTS} \
+    --go-vtproto_opt=features=marshal+unmarshal+size+clone,module=github.com/elastic/apm-data \
     ./model/proto/*.proto


### PR DESCRIPTION
The pooling code is not used anymore, so it is not necessary to generate it. Removes pooling code generation from the Makefile and the modelpb generation script.