### PR TITLE
Fix leaking slice capacity

### DIFF
--- a/input/elasticapm/internal/modeldecoder/modeldecoderutil/slice.go
+++ b/input/elasticapm/internal/modeldecoder/modeldecoderutil/slice.go
@@ -27,7 +27,9 @@ func Reslice[Slice ~[]model, model any](slice Slice, n int) Slice {
 	if n > cap(slice) {
 		slice = slices.Grow(slice, n-len(slice))
 	}
-	return slice[:n]
+	res := make(Slice, n)
+	copy(res, slice[:n])
+	return res
 }
 
 // ResliceAndPopulateNil ensures a slice of pointers has atleast


### PR DESCRIPTION
The slicing operation in `Reslice` using `slice[:n]` creates a n-length slice. However, its capacity remains the same as the initial slice. The remaining elements are still allocated in memory. The backing array of the slice still contains n-elements after the slicing operation.

As a result, the remaining space won’t be reclaimed by the GC, and we can keep a large backing array despite using only a few elements.

This change is really only practical when working with large slices. However, I'm deducing with my limit contextual understanding, that optimization is the purpose of this reslicing function.