### PR TITLE
elasticapm: Default log.level:error for errors

### DIFF
--- a/input/elasticapm/internal/modeldecoder/rumv3/decoder.go
+++ b/input/elasticapm/internal/modeldecoder/rumv3/decoder.go
@@ -185,7 +185,7 @@ func mapToErrorModel(from *errorEvent, event *modelpb.APMEvent) {
 		out.Id = from.ID.Val
 	}
 	if from.Log.IsSet() {
-		log := modelpb.ErrorLog{}
+		log := modelpb.ErrorLog{Level: "error"}
 		if from.Log.Level.IsSet() {
 			log.Level = from.Log.Level.Val
 		}

--- a/input/elasticapm/internal/modeldecoder/rumv3/error_test.go
+++ b/input/elasticapm/internal/modeldecoder/rumv3/error_test.go
@@ -51,6 +51,7 @@ func TestDecodeNestedError(t *testing.T) {
 		assert.Empty(t, cmp.Diff(&modelpb.Error{
 			Id: "a-b-c",
 			Log: &modelpb.ErrorLog{
+				Level:      "error",
 				Message:    "abc",
 				LoggerName: "default",
 			},
@@ -189,6 +190,15 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		mapToErrorModel(&input, &out)
 		require.NotNil(t, out.Error.Log.LoggerName)
 		assert.Equal(t, "default", out.Error.Log.LoggerName)
+	})
+
+	t.Run("logLevel", func(t *testing.T) {
+		var input errorEvent
+		input.Log.Level.Set("warn")
+		var out modelpb.APMEvent
+		mapToErrorModel(&input, &out)
+		require.NotNil(t, out.Error.Log.Level)
+		assert.Equal(t, "warn", out.Error.Log.Level)
 	})
 
 	t.Run("http-headers", func(t *testing.T) {

--- a/input/elasticapm/internal/modeldecoder/v2/decoder.go
+++ b/input/elasticapm/internal/modeldecoder/v2/decoder.go
@@ -369,7 +369,7 @@ func mapToErrorModel(from *errorEvent, event *modelpb.APMEvent) {
 		out.Id = from.ID.Val
 	}
 	if from.Log.IsSet() {
-		log := modelpb.ErrorLog{}
+		log := modelpb.ErrorLog{Level: "error"}
 		if from.Log.Level.IsSet() {
 			log.Level = from.Log.Level.Val
 		}

--- a/input/elasticapm/internal/modeldecoder/v2/error_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/error_test.go
@@ -51,7 +51,7 @@ func TestDecodeNestedError(t *testing.T) {
 		assert.Equal(t, modelpb.FromTime(time.Unix(1599996822, 281000000)), batch[0].Timestamp)
 		assert.Empty(t, cmp.Diff(&modelpb.Error{
 			Id:  "a-b-c",
-			Log: &modelpb.ErrorLog{Message: "abc"},
+			Log: &modelpb.ErrorLog{Level: "error", Message: "abc"},
 		}, batch[0].Error, protocmp.Transform()))
 
 		str = `{"error":{"id":"a-b-c","log":{"message":"abc"},"context":{"experimental":"exp"}}}`
@@ -244,5 +244,14 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		mapToErrorModel(&input, &out)
 		assert.Equal(t, "1234", out.Transaction.Id)
 		assert.Equal(t, "1234", out.Span.Id)
+	})
+
+	t.Run("log.level", func(t *testing.T) {
+		var input errorEvent
+		input.Log.Level.Set("warn")
+		var out modelpb.APMEvent
+		mapToErrorModel(&input, &out)
+		require.NotNil(t, out.Error.Log.Level)
+		assert.Equal(t, "warn", out.Error.Log.Level)
 	})
 }


### PR DESCRIPTION
Updates the decoder to set the default log.level to error for errors. It only applies to the Elastic APM Intake protocol.

Part of elastic/apm-server#13956