### PR TITLE
Add field for span http request body to IntakeV2

### DIFF
--- a/input/elasticapm/docs/spec/v2/span.json
+++ b/input/elasticapm/docs/spec/v2/span.json
@@ -188,6 +188,13 @@
                 "object"
               ],
               "properties": {
+                "body": {
+                  "description": "The http request body as a string",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
                 "id": {
                   "description": "ID holds the unique identifier for the http request.",
                   "type": [

--- a/input/elasticapm/internal/modeldecoder/v2/decoder.go
+++ b/input/elasticapm/internal/modeldecoder/v2/decoder.go
@@ -1071,14 +1071,19 @@ func mapToSpanModel(from *span, event *modelpb.APMEvent) {
 			}
 			event.Http.Request.Method = from.Context.HTTP.Method.Val
 		}
-		if from.Context.HTTP.Request.ID.IsSet() {
+		if from.Context.HTTP.Request.IsSet() {
 			if event.Http == nil {
 				event.Http = &modelpb.HTTP{}
 			}
 			if event.Http.Request == nil {
 				event.Http.Request = &modelpb.HTTPRequest{}
 			}
-			event.Http.Request.Id = from.Context.HTTP.Request.ID.Val
+			if from.Context.HTTP.Request.ID.IsSet() {
+				event.Http.Request.Id = from.Context.HTTP.Request.ID.Val
+			}
+			if from.Context.HTTP.Request.Body.IsSet() {
+				event.Http.Request.Body = modeldecoderutil.ToValue(from.Context.HTTP.Request.Body.Val)
+			}
 		}
 		if from.Context.HTTP.Response.IsSet() {
 			if event.Http == nil {

--- a/input/elasticapm/internal/modeldecoder/v2/model.go
+++ b/input/elasticapm/internal/modeldecoder/v2/model.go
@@ -845,6 +845,8 @@ type spanContextHTTP struct {
 type spanContextHTTPRequest struct {
 	// ID holds the unique identifier for the http request.
 	ID nullable.String `json:"id"`
+	// The http request body as a string
+	Body nullable.String `json:"body"`
 }
 
 type spanContextHTTPResponse struct {

--- a/input/elasticapm/internal/modeldecoder/v2/model_generated.go
+++ b/input/elasticapm/internal/modeldecoder/v2/model_generated.go
@@ -2500,11 +2500,12 @@ func (val *spanContextHTTP) processNestedSource() error {
 }
 
 func (val *spanContextHTTPRequest) IsSet() bool {
-	return val.ID.IsSet()
+	return val.ID.IsSet() || val.Body.IsSet()
 }
 
 func (val *spanContextHTTPRequest) Reset() {
 	val.ID.Reset()
+	val.Body.Reset()
 }
 
 func (val *spanContextHTTPRequest) validate() error {

--- a/input/elasticapm/internal/modeldecoder/v2/span_test.go
+++ b/input/elasticapm/internal/modeldecoder/v2/span_test.go
@@ -19,6 +19,7 @@ package v2
 
 import (
 	"encoding/json"
+	"google.golang.org/protobuf/types/known/structpb"
 	"net/http"
 	"strconv"
 	"strings"
@@ -258,12 +259,20 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		}
 	})
 
-	t.Run("http-request", func(t *testing.T) {
+	t.Run("http-request-id", func(t *testing.T) {
 		var input span
 		input.Context.HTTP.Request.ID.Set("some-request-id")
 		var out modelpb.APMEvent
 		mapToSpanModel(&input, &out)
 		assert.Equal(t, "some-request-id", out.Http.Request.Id)
+	})
+
+	t.Run("http-request-body", func(t *testing.T) {
+		var input span
+		input.Context.HTTP.Request.Body.Set("some-request-body")
+		var out modelpb.APMEvent
+		mapToSpanModel(&input, &out)
+		assert.Equal(t, structpb.NewStringValue("some-request-body"), out.Http.Request.Body)
 	})
 
 	t.Run("http-headers", func(t *testing.T) {

--- a/model/modeljson/http.pb.json_test.go
+++ b/model/modeljson/http.pb.json_test.go
@@ -18,6 +18,7 @@
 package modeljson
 
 import (
+	"google.golang.org/protobuf/types/known/structpb"
 	"testing"
 
 	modeljson "github.com/elastic/apm-data/model/modeljson/internal"
@@ -51,6 +52,7 @@ func TestHTTPToModelJSON(t *testing.T) {
 					Id:       "id",
 					Method:   "method",
 					Referrer: "referrer",
+					Body:     structpb.NewStringValue("request-body"),
 				},
 			},
 			expected: &modeljson.HTTP{
@@ -61,6 +63,9 @@ func TestHTTPToModelJSON(t *testing.T) {
 					ID:       "id",
 					Method:   "method",
 					Referrer: "referrer",
+					Body: &modeljson.HTTPRequestBody{
+						Original: "request-body",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Part of https://github.com/elastic/apm-agent-java/issues/3788.

The idea of this PR was to add a new field to Intake V2 to allow storing of HTTP client request bodies (therefore on spans instead of transactions) into the existing `http.request.body.original` elasticsearch field.

I initially though this would be trivial, because `http.request.body.original` is already populated from transactions. Because in modelpb the `HTTP` data structure is shared for spans and transactions, I expected that no additional changes (e.g. in apm-package are necessary).

However, this doesn't seem to work: Even though the tests show that `modelpb Http.Request.Body` is correctly populated from IntakeV2 spans, `http.request.body.original` is not populated for spans in elasticsearch.

Some hints where to look would be great, I already extended the tests showing that the body is correctly populated for modeljson...