### PR TITLE
github-actions: use ephemeral tokens for add the different projects board and labels

### DIFF
--- a/.github/workflows/add-to-apm-project.yaml
+++ b/.github/workflows/add-to-apm-project.yaml
@@ -10,6 +10,18 @@ jobs:
   add_to_project:
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "organization_projects": "write",
+              "issues": "read"
+            }
+
       - uses: octokit/graphql-action@v2.x
         id: add_to_project
         with:
@@ -27,7 +39,7 @@ jobs:
           contentid: ${{ github.event.issue.node_id }}
         env:
           PROJECT_ID: "PVT_kwDOAGc3Zs0VSg"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
       - uses: octokit/graphql-action@v2.x
         id: label_team
         with:
@@ -50,4 +62,4 @@ jobs:
           value: "6c538d8a"
         env:
           PROJECT_ID: "PVT_kwDOAGc3Zs0VSg"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -14,7 +14,19 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "organization_projects": "write",
+              "issues": "read"
+            }
+
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/elastic/projects/1286
-          github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/label-elastic-pull-requests.yml
+++ b/.github/workflows/label-elastic-pull-requests.yml
@@ -11,18 +11,29 @@ jobs:
   safe-to-test:
     runs-on: ubuntu-latest
     steps:
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "members": "read",
+            "pull_requests": "write"
+          }
     - name: Check team membership for user
       uses: elastic/get-user-teams-membership@1.1.0
       id: checkUserMember
       with:
         username: ${{ github.actor }}
         team: 'apm'
-        GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
     - name: Add safe-to-test label
       uses: actions/github-script@v7
       if: steps.checkUserMember.outputs.isTeamMember == 'true'
       with:
-        github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
+        github-token: ${{ steps.get_token.outputs.token }}
         script: |
           github.rest.issues.addLabels({
             issue_number: context.issue.number,


### PR DESCRIPTION
Support for ephemeral GH tokens instead of using finer-grained tokens