### PR TITLE
Fix Flaky Semaphore Test

### DIFF
--- a/input/otlp/logs_test.go
+++ b/input/otlp/logs_test.go
@@ -226,7 +226,6 @@ func TestConsumerConsumeLogs(t *testing.T) {
 
 func TestConsumeLogsSemaphore(t *testing.T) {
 	logs := plog.NewLogs()
-	var batches []*modelpb.Batch
 
 	var once sync.Once
 	semAcquiredCh := make(chan struct{})
@@ -238,8 +237,6 @@ func TestConsumeLogsSemaphore(t *testing.T) {
 			close(semAcquiredCh)
 		})
 		<-doneCh
-		batchCopy := batch.Clone()
-		batches = append(batches, &batchCopy)
 		return nil
 	})
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{

--- a/input/otlp/metrics_test.go
+++ b/input/otlp/metrics_test.go
@@ -228,7 +228,6 @@ func TestConsumeMetrics(t *testing.T) {
 
 func TestConsumeMetricsSemaphore(t *testing.T) {
 	metrics := pmetric.NewMetrics()
-	var batches []*modelpb.Batch
 
 	var once sync.Once
 	semAcquiredCh := make(chan struct{})
@@ -240,8 +239,6 @@ func TestConsumeMetricsSemaphore(t *testing.T) {
 			close(semAcquiredCh)
 		})
 		<-doneCh
-		batchCopy := batch.Clone()
-		batches = append(batches, &batchCopy)
 		return nil
 	})
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{

--- a/input/otlp/traces_test.go
+++ b/input/otlp/traces_test.go
@@ -1167,7 +1167,6 @@ func TestSpanLinks(t *testing.T) {
 
 func TestConsumeTracesSemaphore(t *testing.T) {
 	traces := ptrace.NewTraces()
-	var batches []*modelpb.Batch
 
 	var once sync.Once
 	semAcquiredCh := make(chan struct{})
@@ -1179,8 +1178,6 @@ func TestConsumeTracesSemaphore(t *testing.T) {
 			close(semAcquiredCh)
 		})
 		<-doneCh
-		batchCopy := batch.Clone()
-		batches = append(batches, &batchCopy)
 		return nil
 	})
 	consumer := otlp.NewConsumer(otlp.ConsumerConfig{


### PR DESCRIPTION
Closes https://github.com/elastic/apm-data/issues/361

## Context

Testing `apm-data` with `-race` causes a deadlock, since the semaphore is not properly released.

The [TestConsumeLogsSemaphore](https://github.com/elastic/apm-data/blob/46f8e38486b772090fbf1fdccc8eeea13c513075/input/otlp/logs_test.go#L226) basically consists of 3 parts:

1. Spin up a goroutine that runs a consumer in parallel with the main routine. The purpose of this child routine is to acquire the semaphore until [close(doneCh)](https://github.com/elastic/apm-data/blob/46f8e38486b772090fbf1fdccc8eeea13c513075/input/otlp/logs_test.go#L254).
2. The main routine spins up its own consumer, which after attempting for some time to acquire the semaphore, will return with an expected error.
3. After the expected error, finish running the parallel routine in (1) to release the semaphore. Main runs a last consumer to ensure it can properly acquire the released lock.

## Solution

Removing the following lines from function [semAcquire](https://github.com/elastic/apm-data/blob/46f8e38486b772090fbf1fdccc8eeea13c513075/input/otlp/trace_semaphore.go#L29) seems to fix the issue.
```
sp, ctx := apm.StartSpan(ctx, "Semaphore.Acquire", "Reporter")
defer sp.End()
```

Initially, I thought the problem was _propagating an inappropriate context_, but passing a background context and removing the context shadowing, didn't solve the problem. 

The only reasonable explanation, therefore, is the span introduces enough of a lag such that [Goroutine 1](https://github.com/elastic/apm-data/blob/46f8e38486b772090fbf1fdccc8eeea13c513075/input/otlp/logs_test.go#L245) does not acquire the semaphore first, before [Main](https://github.com/elastic/apm-data/blob/46f8e38486b772090fbf1fdccc8eeea13c513075/input/otlp/logs_test.go#L252) starts competing for it, leading to a  deadlock.

The deadlock is solved by "upgrading" the [startCh](https://github.com/elastic/apm-data/blob/46f8e38486b772090fbf1fdccc8eeea13c513075/input/otlp/logs_test.go#L242) to sync the parallel running goroutine with main, not when it starts, but when it has fully acquired the semaphore. This is the purpose of `semAcquiredCh`.

However, since the processor is executed multiple times, for the context of this test we only want to sync the first acquisition. Hence, the use of `sync.Once`. 

## Update

The tests were update to remove `sync.Once` using the suggestion by @1pkg in the comments below: https://github.com/elastic/apm-data/pull/391#discussion_r1830180915

## Test

```
go clean -testcache
go test -race -v -failfast ./input/otlp
```