### PR TITLE
Add specific type and subtype for otlp gen_ai spans

### DIFF
--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -82,6 +82,7 @@ const (
 	attributeStackTrace                 = "code.stacktrace" // semconv 1.24 or later
 	attributeDataStreamDataset          = "data_stream.dataset"
 	attributeDataStreamNamespace        = "data_stream.namespace"
+	attributeGenAiSystem                = "gen_ai.system"
 )
 
 // ConsumeTracesResult contains the number of rejected spans and error message for partial success response.
@@ -817,7 +818,7 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 				event.Code.Stacktrace = v.Str()
 
 			// gen_ai.*
-			case "gen_ai.system":
+			case attributeGenAiSystem:
 				genAiSystem = stringval
 				isGenAi = true
 

--- a/input/otlp/traces_test.go
+++ b/input/otlp/traces_test.go
@@ -1438,6 +1438,16 @@ func TestSpanEventsDataStream(t *testing.T) {
 	}
 }
 
+func TestGenAiSpan(t *testing.T) {
+	event := transformSpanWithAttributes(t, map[string]interface{}{
+		"gen_ai.system": "openai",
+	})
+
+	assert.Equal(t, "genai", event.Span.Type)
+	assert.Equal(t, "openai", event.Span.Subtype)
+	assert.Equal(t, "", event.Span.Action)
+}
+
 func transformTransactionWithAttributes(t *testing.T, attrs map[string]interface{}, configFns ...func(ptrace.Span)) *modelpb.APMEvent {
 	traces, spans := newTracesSpans()
 	otelSpan := spans.Spans().AppendEmpty()


### PR DESCRIPTION
This matches what has been done in https://github.com/elastic/opentelemetry-lib/pull/127/