### PR TITLE
Translate OTEL log's InstrumentationScope as logger name

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -119,7 +119,7 @@ func (c *Consumer) convertLogRecord(
 	event := baseEvent.CloneVT()
 	initEventLabels(event)
 
-	translateScopeMetadata(scope, event)
+	translateLogScopeMetadata(scope, event)
 
 	if record.Timestamp() == 0 {
 		event.Timestamp = modelpb.FromTime(record.ObservedTimestamp().AsTime().Add(timeDelta))

--- a/input/otlp/metrics.go
+++ b/input/otlp/metrics.go
@@ -159,7 +159,7 @@ func (c *Consumer) handleScopeMetrics(
 	for key, ms := range ms {
 		event := baseEvent.CloneVT()
 
-		translateScopeMetadata(in.Scope(), event)
+		translateMetricsScopeMetadata(in.Scope(), event)
 
 		event.Timestamp = modelpb.FromTime(key.timestamp.Add(timeDelta))
 		metrs := make([]*modelpb.MetricsetSample, 0, len(ms.samples))

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -178,7 +178,7 @@ func (c *Consumer) convertSpan(
 	representativeCount := getRepresentativeCountFromTracestateHeader(otelSpan.TraceState().AsRaw())
 	event := baseEvent.CloneVT()
 
-	translateScopeMetadata(otelLibrary, event)
+	translateSpanScopeMetadata(otelLibrary, event)
 
 	initEventLabels(event)
 	event.Timestamp = modelpb.FromTime(startTime.Add(timeDelta))


### PR DESCRIPTION
InstrumentationScope usually contains the name of the instrumentation library. However, in the case of logs, it may also contain the name of the logger if the log source defines it, see [here][1]. An instrumentation library usually has a version set, so assume that the name without the version is the name of the logger.

[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/api.md#get-a-logger