### PR TITLE
feat: Add user fields mapping to OTLP

### DIFF
--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -199,6 +199,11 @@ func (c *Consumer) convertLogRecord(
 				event.DataStream = &modelpb.DataStream{}
 			}
 			event.DataStream.Namespace = sanitizeDataStreamNamespace(v.Str())
+
+		// user.*
+		case attributeUserID, attributeUserName, attributeUserEmail:
+			addUserFields(k, v, event)
+
 		default:
 			setLabel(replaceDots(k), event, v)
 		}

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -242,8 +242,6 @@ func translateResourceMetadata(resource pcommon.Resource, out *modelpb.APMEvent)
 			}
 			out.User.Name = truncate(v.Str())
 
-		// TODO(eric): Check if `user.*` fields are considered resource metadata?
-
 		// os.*
 		case semconv.AttributeOSType:
 			if out.Host == nil {
@@ -474,8 +472,6 @@ func translateScopeMetadata(scope pcommon.InstrumentationScope, out *modelpb.APM
 			out.DataStream.Namespace = sanitizeDataStreamNamespace(v.Str())
 		}
 
-		// TODO(eric): Check if `user.*` fields are considered scope metadata?
-
 		return true
 	})
 
@@ -588,16 +584,16 @@ func replaceReservedRune(disallowedRunes string) func(r rune) rune {
 
 // NOTE: This will overwrite user fields set by `user.name=process.owner` from `otlp/metadata.go:translateResourceMetadata`.
 func addUserFields(attrKey string, attrVal pcommon.Value, event *modelpb.APMEvent) {
-	if updateEvent.User == nil {
-		updateEvent.User = &modelpb.User{}
+	if event.User == nil {
+		event.User = &modelpb.User{}
 	}
 
 	switch attrKey {
 	case attributeUserID:
-		updateEvent.User.Id = truncate(attrVal.Str())
+		event.User.Id = truncate(attrVal.Str())
 	case attributeUserName:
-		updateEvent.User.Name = truncate(attrVal.Str())
+		event.User.Name = truncate(attrVal.Str())
 	case attributeUserEmail:
-		updateEvent.User.Email = truncate(attrVal.Str())
+		event.User.Email = truncate(attrVal.Str())
 	}
 }

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -242,6 +242,8 @@ func translateResourceMetadata(resource pcommon.Resource, out *modelpb.APMEvent)
 			}
 			out.User.Name = truncate(v.Str())
 
+		// TODO(eric): Check if `user.*` fields are considered resource metadata?
+
 		// os.*
 		case semconv.AttributeOSType:
 			if out.Host == nil {
@@ -471,6 +473,9 @@ func translateScopeMetadata(scope pcommon.InstrumentationScope, out *modelpb.APM
 			}
 			out.DataStream.Namespace = sanitizeDataStreamNamespace(v.Str())
 		}
+
+		// TODO(eric): Check if `user.*` fields are considered scope metadata?
+
 		return true
 	})
 

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -580,3 +580,19 @@ func replaceReservedRune(disallowedRunes string) func(r rune) rune {
 		return unicode.ToLower(r)
 	}
 }
+
+// NOTE: This will overwrite user fields set by `user.name=process.owner` from `otlp/metadata.go:translateResourceMetadata`.
+func addUserFields(attrKey string, attrVal pcommon.Value, updateEvent *modelpb.APMEvent) {
+	if updateEvent.User == nil {
+		updateEvent.User = &modelpb.User{}
+	}
+
+	switch attrKey {
+	case attributeUserID:
+		updateEvent.User.Id = truncate(attrVal.Str())
+	case attributeUserName:
+		updateEvent.User.Name = truncate(attrVal.Str())
+	case attributeUserEmail:
+		updateEvent.User.Email = truncate(attrVal.Str())
+	}
+}

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -587,7 +587,7 @@ func replaceReservedRune(disallowedRunes string) func(r rune) rune {
 }
 
 // NOTE: This will overwrite user fields set by `user.name=process.owner` from `otlp/metadata.go:translateResourceMetadata`.
-func addUserFields(attrKey string, attrVal pcommon.Value, updateEvent *modelpb.APMEvent) {
+func addUserFields(attrKey string, attrVal pcommon.Value, event *modelpb.APMEvent) {
 	if updateEvent.User == nil {
 		updateEvent.User = &modelpb.User{}
 	}

--- a/input/otlp/metadata_test.go
+++ b/input/otlp/metadata_test.go
@@ -18,6 +18,7 @@
 package otlp_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -412,4 +413,76 @@ func transformResourceMetadata(t *testing.T, resourceAttrs map[string]interface{
 	(*events)[0].Event = nil
 	(*events)[0].Timestamp = 0
 	return (*events)[0]
+}
+
+type userField struct {
+	userID    string
+	userName  string
+	userEmail string
+}
+
+type userFieldsTestCase struct {
+	name         string
+	processOwner string
+	input        userField
+	expected     userField
+}
+
+func userFieldsTestCases() []userFieldsTestCase {
+	return []userFieldsTestCase{
+		{
+			name: "default",
+			input: userField{
+				userID:    "123",
+				userName:  "hello",
+				userEmail: "hello@example.com",
+			},
+			expected: userField{
+				userID:    "123",
+				userName:  "hello",
+				userEmail: "hello@example.com",
+			},
+		},
+		{
+			name:         "process owner not overwritten",
+			processOwner: "i-am-the-owner",
+			input: userField{
+				userID:    "123",
+				userName:  "",
+				userEmail: "hello@example.com",
+			},
+			expected: userField{
+				userID:    "123",
+				userName:  "i-am-the-owner",
+				userEmail: "hello@example.com",
+			},
+		},
+		{
+			name:         "overwrite process owner",
+			processOwner: "i-am-the-owner",
+			input: userField{
+				userID:    "123",
+				userName:  "hello",
+				userEmail: "hello@example.com",
+			},
+			expected: userField{
+				userID:    "123",
+				userName:  "hello",
+				userEmail: "hello@example.com",
+			},
+		},
+		{
+			name: "truncate",
+			input: userField{
+				userID:    strings.Repeat("a", 2000),
+				userName:  strings.Repeat("b", 2000),
+				userEmail: strings.Repeat("c", 2000),
+			},
+			expected: userField{
+				userID:    strings.Repeat("a", 1024),
+				userName:  strings.Repeat("b", 1024),
+				userEmail: strings.Repeat("c", 1024),
+			},
+		},
+	}
 }

--- a/input/otlp/metrics.go
+++ b/input/otlp/metrics.go
@@ -243,11 +243,11 @@ func (c *Consumer) handleScopeMetrics(
 						event.Event = &modelpb.Event{}
 					}
 					event.Event.Module = v.Str()
-				case "user.name":
-					if event.User == nil {
-						event.User = &modelpb.User{}
-					}
-					event.User.Name = truncate(v.Str())
+
+				// user.*
+				case attributeUserID, attributeUserName, attributeUserEmail:
+					addUserFields(k, v, event)
+
 				default:
 					setLabel(k, event, v)
 				}

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -83,6 +83,11 @@ const (
 	attributeDataStreamDataset          = "data_stream.dataset"
 	attributeDataStreamNamespace        = "data_stream.namespace"
 	attributeGenAiSystem                = "gen_ai.system"
+	// User fields, refer to https://github.com/elastic/apm-server/issues/15254.
+	// There are other user fields in OTel, but they don't have 1-to-1 mapping to `APMEvent.User`.
+	attributeUserName  = "user.name"
+	attributeUserID    = "user.id"
+	attributeUserEmail = "user.email"
 )
 
 // ConsumeTracesResult contains the number of rejected spans and error message for partial success response.
@@ -1170,6 +1175,11 @@ func (c *Consumer) convertSpanEvent(
 					event.DataStream = &modelpb.DataStream{}
 				}
 				event.DataStream.Namespace = sanitizeDataStreamNamespace(v.Str())
+
+			// user.*
+			case attributeUserID, attributeUserName, attributeUserEmail:
+				addUserFields(k, v, event)
+
 			default:
 				k = replaceDots(k)
 				if isJaeger && k == "message" {

--- a/input/otlp/traces.go
+++ b/input/otlp/traces.go
@@ -491,6 +491,11 @@ func TranslateTransaction(
 					event.DataStream = &modelpb.DataStream{}
 				}
 				event.DataStream.Namespace = sanitizeDataStreamNamespace(stringval)
+
+			// user.*
+			case attributeUserID, attributeUserName, attributeUserEmail:
+				addUserFields(k, v, event)
+
 			default:
 				modelpb.Labels(event.Labels).Set(k, stringval)
 			}
@@ -843,6 +848,11 @@ func TranslateSpan(spanKind ptrace.SpanKind, attributes pcommon.Map, event *mode
 					event.DataStream = &modelpb.DataStream{}
 				}
 				event.DataStream.Namespace = sanitizeDataStreamNamespace(stringval)
+
+			// user.*
+			case attributeUserID, attributeUserName, attributeUserEmail:
+				addUserFields(k, v, event)
+
 			default:
 				setLabel(k, event, v)
 			}


### PR DESCRIPTION
## ❓ Why is this being changed
Related to elastic/apm-server#15254

## 🧑‍💻 What is being changed
Map the following user fields from OTel attributes to `APMEvent.User`
- `user.id`
- `user.name`
- `user.email`

The other user fields do not have equivalents in `APMEvent.User`, so they will still be under `APMEvent.Labels`.

## ✅ How to validate the change
Run test on APM server with the changes

