### PR TITLE
fix: Truncate string slice attributes in OTLP labels

### DIFF
--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -516,7 +516,7 @@ func setLabel(key string, event *modelpb.APMEvent, v pcommon.Value) {
 			for i := 0; i < s.Len(); i++ {
 				r := s.At(i)
 				if r.Type() == pcommon.ValueTypeStr {
-					result = append(result, r.Str())
+					result = append(result, truncate(r.Str()))
 				}
 			}
 			modelpb.Labels(event.Labels).SetSlice(key, result)


### PR DESCRIPTION
## ❓ Why is this being changed
Related to elastic/apm-server#14716

## 🧑‍💻 What is being changed
- Truncate the strings in slices when setting label attributes

## ✅ How to validate the change
Run test on APM server with the changes
