### PR TITLE
Update support for semconv versions up to semconv 1.27.0

### DIFF
--- a/input/otlp/exceptions_test.go
+++ b/input/otlp/exceptions_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/elastic/apm-data/model/modelpb"

--- a/input/otlp/logs.go
+++ b/input/otlp/logs.go
@@ -42,7 +42,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/elastic/apm-data/model/modelpb"
 )
@@ -180,7 +180,7 @@ func (c *Consumer) convertLogRecord(
 				event.Session = &modelpb.Session{}
 			}
 			event.Session.Id = v.Str()
-		case attributeNetworkConnectionType:
+		case semconv.AttributeNetworkConnectionType:
 			if event.Network == nil {
 				event.Network = &modelpb.Network{}
 			}

--- a/input/otlp/logs_test.go
+++ b/input/otlp/logs_test.go
@@ -46,7 +46,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -280,6 +280,7 @@ func TestConsumerConsumeLogsException(t *testing.T) {
 	record2 := newLogRecord("bar")
 	record2.Attributes().PutStr("event.name", "crash")
 	record2.Attributes().PutStr("event.domain", "device")
+	record2.Attributes().PutBool("exception.escaped", true)
 	record2.Attributes().PutStr("exception.type", "HighLevelException")
 	record2.Attributes().PutStr("exception.message", "MidLevelException: LowLevelException")
 	record2.Attributes().PutStr("exception.stacktrace", `
@@ -359,7 +360,7 @@ Caused by: LowLevelException
 			Exception: &modelpb.Exception{
 				Type:    "HighLevelException",
 				Message: "MidLevelException: LowLevelException",
-				Handled: newBool(true),
+				Handled: newBool(false),
 				Stacktrace: []*modelpb.StacktraceFrame{{
 					Classname: "Junk",
 					Function:  "a",
@@ -373,7 +374,7 @@ Caused by: LowLevelException
 				}},
 				Cause: []*modelpb.Exception{{
 					Message: "MidLevelException: LowLevelException",
-					Handled: newBool(true),
+					Handled: newBool(false),
 					Stacktrace: []*modelpb.StacktraceFrame{{
 						Classname: "Junk",
 						Function:  "c",
@@ -397,7 +398,7 @@ Caused by: LowLevelException
 					}},
 					Cause: []*modelpb.Exception{{
 						Message: "LowLevelException",
-						Handled: newBool(true),
+						Handled: newBool(false),
 						Stacktrace: []*modelpb.StacktraceFrame{{
 							Classname: "Junk",
 							Function:  "e",

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -25,7 +25,8 @@ import (
 	"unicode"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/collector/semconv/v1.25.0"
+	semconv26 "go.opentelemetry.io/collector/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/elastic/apm-data/model/modelpb"
 )
@@ -66,8 +67,7 @@ func translateResourceMetadata(resource pcommon.Resource, out *modelpb.APMEvent)
 			out.Service.Node.Name = truncate(v.Str())
 
 		// deployment.*
-		// deployment.environment is deprecated, use deployment.environment.name instead
-		case semconv.AttributeDeploymentEnvironment, "deployment.environment.name":
+		case semconv26.AttributeDeploymentEnvironment, semconv.AttributeDeploymentEnvironmentName:
 			if out.Service == nil {
 				out.Service = &modelpb.Service{}
 			}


### PR DESCRIPTION
The goal of this PR is to support the latest semantic conventions for already mapped otel attributes, without introducing any breaking changes. This is desirable so that users can upgrade their agent SDKs to newer versions without losing semantics when data are mapped with this library. 
Backwards compatibility is achieved by keeping the deprecated field names in the mapping. Where possible, the new field names were added. In cases where no new field names are defined by otel, the fields would be stored as labels instead of concrete mappings, however this would be a breaking change in the semantic conventions itself, rather than in the apm-data mapping logic. 

The mapping logic is taken from https://opentelemetry.io/schemas/1.27.0 as much as possible, and otherwise where possible from the deprecation notes in the semconv version implementations. 

This PR does not introduce support for additional, previously unmapped otel fields.
