### PR TITLE
Update go to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/apm-data
 
-go 1.23
+go 1.23.6
 
 require (
 	github.com/elastic/opentelemetry-lib v0.14.0


### PR DESCRIPTION
Update go version to 1.23.6 to unblock https://github.com/elastic/apm-data/pull/449.