### PR TITLE
feat: ignore NaN float values

### DIFF
--- a/input/elasticapm/internal/modeldecoder/nullable/nullable.go
+++ b/input/elasticapm/internal/modeldecoder/nullable/nullable.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -67,6 +68,26 @@ func init() {
 		switch iter.WhatIsNext() {
 		case jsoniter.NilValue:
 			iter.ReadNil()
+		case jsoniter.InvalidValue:
+			iter.Skip()
+			originalError := iter.Error
+			if !strings.HasPrefix(iter.Error.Error(), "Skip: do not know how to skip: 78,") {
+				return
+			}
+			iter.Error = nil
+			iter.Skip()
+			if !strings.HasPrefix(iter.Error.Error(), "Skip: do not know how to skip: 97,") {
+				iter.Error = originalError
+				return
+			}
+			iter.Error = nil
+			iter.Skip()
+			if !strings.HasPrefix(iter.Error.Error(), "Skip: do not know how to skip: 78,") {
+				iter.Error = originalError
+				return
+			}
+			// ignore NaN as a float value even though it is not valid json
+			iter.Error = nil
 		default:
 			(*((*Float64)(ptr))).Val = iter.ReadFloat64()
 			(*((*Float64)(ptr))).isSet = true

--- a/input/elasticapm/internal/modeldecoder/nullable/nullable_test.go
+++ b/input/elasticapm/internal/modeldecoder/nullable/nullable_test.go
@@ -166,6 +166,8 @@ func TestFloat64(t *testing.T) {
 		{name: "null", input: `{"f":null}`, isSet: false},
 		{name: "missing", input: `{}`},
 		{name: "invalid", input: `{"f":"1.0.1"}`, fail: true},
+		{name: "ignore", input: `{"f":NaN}`, fail: false, isSet: false},
+		{name: "invalid", input: `{"f":NaaN}`, fail: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dec := json.NewDecoder(strings.NewReader(tc.input))


### PR DESCRIPTION
several clients are sending NaN in float values
ignore it to be more resilient even though it's not valid json