### PR TITLE
feat: add readBatch span

### DIFF
--- a/input/elasticapm/processor.go
+++ b/input/elasticapm/processor.go
@@ -179,7 +179,7 @@ func (p *Processor) readBatch(
 	reader *streamReader,
 	result *Result,
 ) (int, error) {
-	ctx, sp := p.tracer.Start(ctx, "readBatch")
+	_, sp := p.tracer.Start(ctx, "readBatch")
 	defer sp.End()
 
 	// input events are decoded and appended to the batch


### PR DESCRIPTION
we've observed large 'Stream' traces with a small semaphore or processor usage.
To improve clarity also trace readBatch since it was observed causing slow requests in some instances