### PR TITLE
otlp: handle host.ip attribute data type more defensively

### DIFF
--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -195,7 +195,7 @@ func translateResourceMetadata(resource pcommon.Resource, out *modelpb.APMEvent)
 				out.Host = &modelpb.Host{}
 			}
 			if v.Type() != pcommon.ValueTypeSlice {
-				break
+				break // switch
 			}
 			slice := v.Slice()
 			result := make([]*modelpb.IP, 0, slice.Len())

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -194,7 +194,13 @@ func translateResourceMetadata(resource pcommon.Resource, out *modelpb.APMEvent)
 			if out.Host == nil {
 				out.Host = &modelpb.Host{}
 			}
-			slice := v.Slice()
+			slice := pcommon.NewSlice()
+			switch v.Type() {
+			case pcommon.ValueTypeSlice:
+				slice = v.Slice()
+			case pcommon.ValueTypeStr:
+				_ = slice.FromRaw([]any{v.Str()})
+			}
 			result := make([]*modelpb.IP, 0, slice.Len())
 			for i := 0; i < slice.Len(); i++ {
 				ip, err := modelpb.ParseIP(slice.At(i).Str())

--- a/input/otlp/metadata.go
+++ b/input/otlp/metadata.go
@@ -194,13 +194,10 @@ func translateResourceMetadata(resource pcommon.Resource, out *modelpb.APMEvent)
 			if out.Host == nil {
 				out.Host = &modelpb.Host{}
 			}
-			slice := pcommon.NewSlice()
-			switch v.Type() {
-			case pcommon.ValueTypeSlice:
-				slice = v.Slice()
-			case pcommon.ValueTypeStr:
-				_ = slice.FromRaw([]any{v.Str()})
+			if v.Type() != pcommon.ValueTypeSlice {
+				break
 			}
+			slice := v.Slice()
 			result := make([]*modelpb.IP, 0, slice.Len())
 			for i := 0; i < slice.Len(); i++ {
 				ip, err := modelpb.ParseIP(slice.At(i).Str())

--- a/input/otlp/metadata_test.go
+++ b/input/otlp/metadata_test.go
@@ -241,6 +241,26 @@ func TestResourceConventions(t *testing.T) {
 				},
 			},
 		},
+		"host_string_ip": {
+			attrs: map[string]interface{}{
+				"host.name": "host_name",
+				"host.id":   "host_id",
+				"host.type": "host_type",
+				"host.arch": "host_arch",
+				"host.ip":   "10.244.0.1",
+			},
+			expected: &modelpb.APMEvent{
+				Agent:   &defaultAgent,
+				Service: &defaultService,
+				Host: &modelpb.Host{
+					Hostname:     "host_name",
+					Id:           "host_id",
+					Type:         "host_type",
+					Architecture: "host_arch",
+					Ip:           []*modelpb.IP{modelpb.MustParseIP("10.244.0.1")},
+				},
+			},
+		},
 		"device": {
 			attrs: map[string]interface{}{
 				"device.id":               "device_id",

--- a/input/otlp/metadata_test.go
+++ b/input/otlp/metadata_test.go
@@ -241,7 +241,7 @@ func TestResourceConventions(t *testing.T) {
 				},
 			},
 		},
-		"host_string_ip": {
+		"host_ip_invalid_type": {
 			attrs: map[string]interface{}{
 				"host.name": "host_name",
 				"host.id":   "host_id",

--- a/input/otlp/metadata_test.go
+++ b/input/otlp/metadata_test.go
@@ -257,7 +257,6 @@ func TestResourceConventions(t *testing.T) {
 					Id:           "host_id",
 					Type:         "host_type",
 					Architecture: "host_arch",
-					Ip:           []*modelpb.IP{modelpb.MustParseIP("10.244.0.1")},
 				},
 			},
 		},


### PR DESCRIPTION
This PR resolves https://github.com/elastic/apm-data/issues/499 by handling OTEL `host.ip` attribute type more defensively.