### PR TITLE
github(codeowners): robots-ci can review .github/workflows only

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 * @elastic/obs-ds-intake-services
 
 # Sub-directories/files ownership
-/.github @elastic/obs-ds-intake-services @elastic/observablt-ci
+/.github/workflows @elastic/obs-ds-intake-services @elastic/observablt-ci


### PR DESCRIPTION
This should help with letting the teams own other files under the .github folder