### PR TITLE
ci: fix ci running twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixed CI jobs running twice for each PR (push + pull request) by updating `on: push` condition.