### PR TITLE
fix: set go version to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/apm-data
 
-go 1.24.1
+go 1.24.0
 
 require (
 	github.com/elastic/opentelemetry-lib v0.21.0


### PR DESCRIPTION
follow the go support policy and support the latest two major versions of go.

set 1.24.0 as the minimum version